### PR TITLE
Add Flutter Actions

### DIFF
--- a/.github/workflows/flutter-action.yml
+++ b/.github/workflows/flutter-action.yml
@@ -1,0 +1,35 @@
+name: Flutter Action
+
+on:
+  push:
+    paths-ignore:
+    - 'documentation/**'
+    - 'LICENSE'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'documentation/**'
+    - 'LICENSE'
+    - 'README.md'
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '12.x'
+    - uses: subosito/flutter-action@v1
+      with:
+        flutter-version: '1.22.5'
+        channel: 'stable'
+    - name: Run Flutter Commands
+      working-directory: ./app
+      run: |
+        flutter pub get
+        flutter format --set-exit-if-changed .
+        flutter analyze .
+        flutter test
+        flutter build apk
+        flutter build ios --release --no-codesign

--- a/.github/workflows/flutter-action.yml
+++ b/.github/workflows/flutter-action.yml
@@ -6,11 +6,6 @@ on:
     - 'documentation/**'
     - 'LICENSE'
     - 'README.md'
-  pull_request:
-    paths-ignore:
-    - 'documentation/**'
-    - 'LICENSE'
-    - 'README.md'
 
 jobs:
   build:

--- a/app/test/main_test.dart
+++ b/app/test/main_test.dart
@@ -1,0 +1,11 @@
+import 'package:app/main.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('HumaneTransportApp says hello world',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(HumaneTransportApp());
+    final textFinder = find.text('Hello World');
+    expect(textFinder, findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #73 .
I've added these Flutter actions after digging through the GitHub Actions marketplace and google for suggestions.
Here are a few things I have questions/concerns/comments about:
1. We're using a combination of `pre-commit` and `flutter` formatting.

I think Flutter handles dart, flutter-y files but not kotlin, java, swift (mmmmaybe?), hence why I have `pre-commit` still (and additional formatting plugins for various IDEs in the relevant wiki page).

2. I don't have `pre-commit` GitHub action set up.

I think it's not likely that we'll be writing in anything besides dart, so I'm hesitant to figure out how to do the `pre-commit` actions (because unlike the `flutter` action, all it does is complain if there's mistakes and you have to manually fix... actually I'm pretty sure the `flutter` action also just complains :( )

3. The GitHub actions aren't magic, they'll run our tests for us (instead of assigning someone to manually do it), but if there's problems you still have to manually fix and push the fixes, and then wait for the tests/formatting/etc. to pass on your PR before you can merge (that's good! but not _totally_ automated).

So... up to you, my reviewer: what should we do now? Should we drop the excess formatters from `pre-commit-config.yaml` and just have it run the `flutter` formatter? Should I add the `pre-commit` GitHub action? Leave it as-is?

**An argument again for keeping `pre-commit` - it will force you to format (and do some formatting for you!) before you even commit, and if it works well, we won't have complains when the `flutter` github actions run besides broken tests, etc. that formatters obviously don't catch.**