### PR TITLE
Add reusable alert dialog

### DIFF
--- a/app/lib/common/widgets/alert_dialog.dart
+++ b/app/lib/common/widgets/alert_dialog.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+launchAlertDialog(BuildContext context,
+        {String title = "Title", String warning = "Warning"}) =>
+    showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+              title: Text(title),
+              content: Text(warning),
+            ));

--- a/app/lib/screens/new_travel/new_travel.dart
+++ b/app/lib/screens/new_travel/new_travel.dart
@@ -1,8 +1,10 @@
+import 'package:app/common/widgets/alert_dialog.dart';
 import 'package:app/screens/new_travel/new_travel_journey/test_screen_one.dart';
 import 'package:flutter/material.dart';
 
 class NewTravel extends StatelessWidget {
   static const route = '/home/new_tavel';
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -27,6 +29,17 @@ class NewTravel extends StatelessWidget {
               onPressed: () => Navigator.of(context, rootNavigator: true)
                   .pushNamed(TestScreenOne.route),
               child: Text('Go Next'),
+            ),
+            SizedBox(
+              height: 50.0,
+            ),
+            Text('See if Future code will run, regardless of current screen'),
+            RaisedButton(
+              onPressed: () async => Future.delayed(Duration(seconds: 2)).then(
+                  (_) => launchAlertDialog(context,
+                      title: "An alert in 2 seconds?",
+                      warning: "I am the Future!")),
+              child: Text('Launch Future (2 seconds delay)'),
             ),
           ],
         ),


### PR DESCRIPTION
Closes #98 . 

From the behaviour of the dialog shown below, we can confirm that `Future` code can be used to call on Firebase, etc. for saving code while the user continues to navigate the application.



https://user-images.githubusercontent.com/32527219/105097526-58f0a380-5a6e-11eb-84a7-278cffc1b7be.mov



If we want to keep any text the transporter entered when editing, say, an ATR, that caching will need to be the result of clever state management of the editing widget. The `Future` code will begin executing once told to do so.

Therefore, I believe there is no need for isolates at this time: I think if the user closes out entirely the application there is a possibility that the Firebase local save will stop, but people generally don't do this as fast as an interruption would need to be, and it is likely the Firebase call will have it's own concurrent code that will execute to finish (but won't have a running app to report to). I think this is not a problem we can recover from without isolates, but the conditions for such an event are like sending an email and then within microseconds you destroy your computer.

In such a case, the local save of the email likely went off without a problem, but remote was interrupted. I think Firebase handles discrepancies between local and remote on its own, too, so we don't have to implement this behaviour ourselves.