### PR TITLE
Add loading screen

### DIFF
--- a/app/lib/common/enums/app_state.dart
+++ b/app/lib/common/enums/app_state.dart
@@ -1,1 +1,0 @@
-enum ViewState { Idle, Busy }

--- a/app/lib/common/style/style.dart
+++ b/app/lib/common/style/style.dart
@@ -36,3 +36,5 @@ const BodyTextStyle = TextStyle(
 const DefaultRaisedButtonStyle = ButtonThemeData(
   buttonColor: Colors.green,
 );
+
+const OverlayColor = Color.fromRGBO(0, 0, 0, 0.5);

--- a/app/lib/common/widgets/loading_overlay_screen.dart
+++ b/app/lib/common/widgets/loading_overlay_screen.dart
@@ -1,0 +1,40 @@
+import 'package:app/common/style/style.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// A factory for a loading overlay screen. Credit https://www.greycastle.se/loading-overlay-in-flutter/
+class LoadingOverlayScreen {
+  BuildContext _context;
+
+  LoadingOverlayScreen._create(this._context);
+
+  factory LoadingOverlayScreen.of(BuildContext context) {
+    return LoadingOverlayScreen._create(context);
+  }
+
+  void hide() {
+    Navigator.of(_context, rootNavigator: true).pop();
+  }
+
+  void show() {
+    showDialog(
+        context: _context,
+        barrierDismissible: false,
+        child: WillPopScope(
+            child: _LoadingOverlayScreen(), onWillPop: () async => false));
+  }
+
+  Future<T> during<T>(Future<T> future) async {
+    show();
+    return future.whenComplete(() => hide());
+  }
+}
+
+class _LoadingOverlayScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        decoration: BoxDecoration(color: OverlayColor),
+        child: Center(child: CircularProgressIndicator()));
+  }
+}

--- a/app/lib/providers/authentication/authentication.dart
+++ b/app/lib/providers/authentication/authentication.dart
@@ -1,34 +1,20 @@
-import 'package:app/common/enums/app_state.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 class AuthenticationProvider extends ChangeNotifier {
   AuthenticationProvider(this._firebaseAuth);
+
   FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
-  ViewState _viewState;
-
-  ViewState get viewState => _viewState;
-
-  void setViewState(ViewState viewState) {
-    _viewState = viewState;
-    notifyListeners();
-  }
 
   Stream<User> get authStateChanges => _firebaseAuth.authStateChanges();
 
   Future<void> signIn({String email, String password}) async {
     try {
-      setViewState(ViewState.Busy);
-      await Future.delayed(Duration(seconds: 2));
-      print(viewState);
       await _firebaseAuth.signInWithEmailAndPassword(
           email: email, password: password);
-      setViewState(ViewState.Idle);
-      print(viewState);
     } on FirebaseAuthException catch (e) {
       // TODO: Handle errors like password incorrect/user not found
       // TODO: Update UI with the error message
-      setViewState(ViewState.Idle);
       print(e.code);
     }
   }
@@ -36,9 +22,6 @@ class AuthenticationProvider extends ChangeNotifier {
   // TODO: Create Account
   Future<void> signUp({String email, String password}) async {
     try {
-      setViewState(ViewState.Busy);
-      await Future.delayed(Duration(seconds: 2));
-      print(viewState);
       await _firebaseAuth.createUserWithEmailAndPassword(
           email: email, password: password);
     } on FirebaseAuthException catch (e) {
@@ -53,7 +36,7 @@ class AuthenticationProvider extends ChangeNotifier {
     await _firebaseAuth.signOut();
   }
 
-  // TODO: Update account information
+// TODO: Update account information
 
-  // TODO: Delete account
+// TODO: Delete account
 }

--- a/app/lib/screens/authenticate/sign_in.dart
+++ b/app/lib/screens/authenticate/sign_in.dart
@@ -1,4 +1,4 @@
-import 'package:app/common/enums/app_state.dart';
+import 'package:app/common/widgets/loading_overlay_screen.dart';
 import 'package:app/navigation/side_bar/sidebar.dart';
 import 'package:app/providers/authentication/authentication.dart';
 import 'package:flutter/material.dart';
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 class SignInScreen extends StatelessWidget {
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -31,18 +32,14 @@ class SignInScreen extends StatelessWidget {
                   controller: passwordController,
                   decoration: InputDecoration(hintText: "Password"),
                 ),
-                // TODO: Add logic that will disable the widget when we're awaiting for response
-                model.viewState == ViewState.Busy
-                    ? CircularProgressIndicator()
-                    : RaisedButton(
-                        onPressed: () {
-                          model.signIn(
-                              email: emailController.text.trim(),
-                              password: passwordController.text.trim());
-                        },
-                        child: Text('Sign In'),
-                        color: Colors.green,
-                      ),
+                RaisedButton(
+                  onPressed: () async => LoadingOverlayScreen.of(context)
+                      .during(model.signIn(
+                          email: emailController.text.trim(),
+                          password: passwordController.text.trim())),
+                  child: Text('Sign In'),
+                  color: Colors.green,
+                ),
                 SizedBox(
                   height: 100.0,
                 ),

--- a/app/lib/screens/new_travel/new_travel.dart
+++ b/app/lib/screens/new_travel/new_travel.dart
@@ -1,5 +1,6 @@
 import 'package:app/common/enums/app_state.dart';
 import 'package:app/common/widgets/alert_dialog.dart';
+import 'package:app/common/widgets/loading_overlay_screen.dart';
 import 'package:app/navigation/side_bar/sidebar.dart';
 import 'package:app/providers/authentication/authentication.dart';
 import 'package:app/screens/new_travel/new_travel_journey/test_screen_one.dart';
@@ -7,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 class NewTravel extends StatelessWidget {
-  static const route = '/home/new_tavel';
+  static const route = '/home/new_travel';
 
   @override
   Widget build(BuildContext context) {
@@ -39,13 +40,23 @@ class NewTravel extends StatelessWidget {
               SizedBox(
                 height: 50.0,
               ),
-              Text('See if Future code will run, regardless of current screen'),
               RaisedButton(
                 onPressed: () async => Future.delayed(Duration(seconds: 2))
                     .then((_) => launchAlertDialog(context,
                         title: "An alert in 2 seconds?",
                         warning: "I am the Future!")),
                 child: Text('Launch Future (2 seconds delay)'),
+              ),
+              SizedBox(
+                height: 50.0,
+              ),
+              RaisedButton(
+                onPressed: () async => LoadingOverlayScreen.of(context)
+                    .during(Future.delayed(Duration(seconds: 5))),
+                child: Text("Launch the loading screen"),
+              ),
+              SizedBox(
+                height: 50.0,
               ),
               model.viewState == ViewState.Busy
                   ? CircularProgressIndicator()

--- a/app/lib/screens/new_travel/new_travel.dart
+++ b/app/lib/screens/new_travel/new_travel.dart
@@ -1,4 +1,3 @@
-import 'package:app/common/enums/app_state.dart';
 import 'package:app/common/widgets/alert_dialog.dart';
 import 'package:app/common/widgets/loading_overlay_screen.dart';
 import 'package:app/navigation/side_bar/sidebar.dart';
@@ -58,15 +57,11 @@ class NewTravel extends StatelessWidget {
               SizedBox(
                 height: 50.0,
               ),
-              model.viewState == ViewState.Busy
-                  ? CircularProgressIndicator()
-                  : RaisedButton(
-                      onPressed: () {
-                        model.signOut();
-                      },
-                      child: Text('Sign Out'),
-                      color: Colors.red,
-                    ),
+              RaisedButton(
+                onPressed: () => model.signOut(),
+                child: Text('Sign Out'),
+                color: Colors.red,
+              ),
             ],
           ),
         ),

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -340,7 +340,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2+4"
+    version: "4.3.3"
   pub_semver:
     dependency: transitive
     description:


### PR DESCRIPTION
Closes #99 .

Added a reusable loading screen. Credit to David at https://www.greycastle.se/loading-overlay-in-flutter/ for such an excellent [factory](https://flutterbyexample.com/lesson/factory-methods). I simply could not do better: this exact pattern shows how we can separate widget logic from business logic, among other very good practices. I stumbled across this example when I was investigating `barrierDismissible`.

I did the below on android because of the availability of a back button.


https://user-images.githubusercontent.com/32527219/105563916-872be880-5ce5-11eb-8349-08af16d5c518.mov

