### PR TITLE
Update iphone sim used to iOS 14.4

### DIFF
--- a/.github/workflows/flutter-action-build-and-integration-testing.yml
+++ b/.github/workflows/flutter-action-build-and-integration-testing.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         device:
-          - iPhone 12 Pro Max (14.2)
+          - iPhone 12 Pro Max (14.4)
       fail-fast: false
     runs-on: macOS-latest
     steps:


### PR DESCRIPTION
Xcode updated in the last few days to iOS 14.4, this changes what simulators are available on GItHub machines. Likely, the down period last night was them updated their machines.