### PR TITLE
Changed iOS to 14.3 (stable)

### DIFF
--- a/.github/workflows/flutter-action-build-and-integration-testing.yml
+++ b/.github/workflows/flutter-action-build-and-integration-testing.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         device:
-          - iPhone 12 Pro Max (14.4)
+          - iPhone 12 Pro Max (14.3)
       fail-fast: false
     runs-on: macOS-latest
     steps:


### PR DESCRIPTION
Follow up to prior PR - XCode updated to 14.4, but GItHub updated to 14.3. We literally have the command "list all devices" in the build flutter action so I would know what the latest devices were, but I missed it. I put it there!!! >:(