### PR TITLE
Fixed buggy GradleException that should be FileNotFoundException in API 29

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -8,7 +8,7 @@ if (localPropertiesFile.exists()) {
 
 def flutterRoot = localProperties.getProperty('flutter.sdk')
 if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
+    throw new FileNotFoundException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -43,6 +43,7 @@ android {
         targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -59,6 +60,7 @@ flutter {
 }
 
 dependencies {
+    implementation 'androidx.multidex:multidex:2.0.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 


### PR DESCRIPTION
Not sure how we didn't catch this before, but can confirm this will appear on windows and mac machines, [stackoverflow](https://github.com/flutter/flutter/issues/29608#issuecomment-619709383).

Also enabled `multidex` because we use Firestore and it's big, [stackoverflow](https://stackoverflow.com/questions/55591958/flutter-firestore-causing-d8-cannot-fit-requested-classes-in-a-single-dex-file).

Tested the build on Android on my mac and see no further problems, build or compile time, that we don't see already (navigator... #162).

***

@MummenRider if you had this on Firebase-API branch already, my bad, I'm adding again.

***

The team should also make sure they are using SDK 29 in their IDE.