### PR TITLE
Add equality operator overloads and bring back toString() for tests

### DIFF
--- a/app/lib/core/models/acknowledgement_info.dart
+++ b/app/lib/core/models/acknowledgement_info.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 
 @immutable
 class AcknowledgementInfo {
+  // TODO: Resolve how to display ack info, if it's an image or w/e
+  // The File type is temporary until we have a ack type
   final File shipperAck;
   final File transporterAck;
   final File receiverAck;
@@ -12,6 +14,18 @@ class AcknowledgementInfo {
       {@required this.shipperAck,
       @required this.transporterAck,
       @required this.receiverAck});
+
+  @override
+  int get hashCode =>
+      shipperAck.hashCode ^ transporterAck.hashCode ^ receiverAck.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is AcknowledgementInfo) &&
+        other.shipperAck == shipperAck &&
+        other.transporterAck == transporterAck &&
+        other.receiverAck == receiverAck;
+  }
 
   AcknowledgementInfo.fromJSON(Map<String, dynamic> json)
       : shipperAck = File(json['shipperAck']),
@@ -24,7 +38,6 @@ class AcknowledgementInfo {
         'receiverAck': receiverAck
       };
 
-  // TODO: Resolve how to display ack info, if it's an image or w/e
   Widget toWidget() {
     return Column(children: [
       ListTile(

--- a/app/lib/core/models/acknowledgement_info.dart
+++ b/app/lib/core/models/acknowledgement_info.dart
@@ -38,6 +38,10 @@ class AcknowledgementInfo {
         'receiverAck': receiverAck
       };
 
+  // TODO: Resolve how to print ack info
+  String toString() =>
+      "Shipper acknowledgement: , Transporter acknowledgement: , Consignee acknowledgement: ";
+
   Widget toWidget() {
     return Column(children: [
       ListTile(

--- a/app/lib/core/models/animal_transport_record.dart
+++ b/app/lib/core/models/animal_transport_record.dart
@@ -31,6 +31,30 @@ class AnimalTransportRecord {
     @required this.identifier,
   });
 
+  @override
+  int get hashCode =>
+      shipInfo.hashCode ^
+      tranInfo.hashCode ^
+      fwrInfo.hashCode ^
+      vehicleInfo.hashCode ^
+      deliveryInfo.hashCode ^
+      ackInfo.hashCode ^
+      contingencyInfo.hashCode ^
+      identifier.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is AnimalTransportRecord) &&
+        other.shipInfo == shipInfo &&
+        other.tranInfo == tranInfo &&
+        other.fwrInfo == fwrInfo &&
+        other.vehicleInfo == vehicleInfo &&
+        other.deliveryInfo == deliveryInfo &&
+        other.ackInfo == ackInfo &&
+        other.contingencyInfo == contingencyInfo &&
+        other.identifier == identifier;
+  }
+
   AnimalTransportRecord.fromJSON(
       Map<String, dynamic> json, String atrDocumentId)
       : shipInfo = ShipperInfo.fromJSON(json['shipInfo']),

--- a/app/lib/core/models/animal_transport_record.dart
+++ b/app/lib/core/models/animal_transport_record.dart
@@ -2,6 +2,7 @@ import 'package:app/core/models/atr_identifier.dart';
 import 'package:app/core/models/shipper_info.dart';
 import 'package:app/core/models/transporter_info.dart';
 import 'package:flutter/material.dart';
+
 import 'acknowledgement_info.dart';
 import 'contingency_plan_info.dart';
 import 'delivery_info.dart';
@@ -51,6 +52,14 @@ class AnimalTransportRecord {
         'contingencyInfo': ackInfo.toJSON(),
         'identifier': identifier.toJSON(),
       };
+
+  String toString() => '''Shipper's Information: $shipInfo
+  Transporter's Information: $tranInfo
+  Feed, Water, and Rest Information: $fwrInfo
+  Loading Vehicle Information: $vehicleInfo
+  Delivery Information: $deliveryInfo
+  Acknowledgements: $ackInfo
+  Contingency Plan: $contingencyInfo''';
 
   AnimalTransportRecord withShipInfo(ShipperInfo newShipInfo) =>
       AnimalTransportRecord(

--- a/app/lib/core/models/contingency_plan_info.dart
+++ b/app/lib/core/models/contingency_plan_info.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -26,6 +27,30 @@ class ContingencyPlanInfo {
         _potentialSafetyActions = potentialSafetyActions,
         _contingencyEvents = contingencyEvents;
 
+  @override
+  int get hashCode =>
+      goalStatement.hashCode ^
+      communicationPlan.hashCode ^
+      _crisisContacts.hashCode ^
+      expectedPrepProcess.hashCode ^
+      standardAnimalMonitoring.hashCode ^
+      _potentialHazards.hashCode ^
+      _potentialSafetyActions.hashCode ^
+      _contingencyEvents.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is ContingencyPlanInfo) &&
+        other.goalStatement == goalStatement &&
+        other.communicationPlan == communicationPlan &&
+        listEquals(other.crisisContacts, _crisisContacts) &&
+        other.expectedPrepProcess == expectedPrepProcess &&
+        other.standardAnimalMonitoring == standardAnimalMonitoring &&
+        listEquals(other.potentialHazards, _potentialHazards) &&
+        listEquals(other.potentialSafetyActions, _potentialSafetyActions) &&
+        listEquals(other.contingencyEvents, _contingencyEvents);
+  }
+
   ContingencyPlanInfo.fromJSON(Map<String, dynamic> json)
       : goalStatement = json['goalStatement'],
         communicationPlan = json['communicationPlan'],
@@ -52,14 +77,14 @@ class ContingencyPlanInfo {
             .toList()
       };
 
-  List<String> crisisContacts() => List.unmodifiable(_crisisContacts);
+  List<String> get crisisContacts => List.unmodifiable(_crisisContacts);
 
-  List<String> potentialHazards() => List.unmodifiable(_potentialHazards);
+  List<String> get potentialHazards => List.unmodifiable(_potentialHazards);
 
-  List<String> potentialSafetyActions() =>
+  List<String> get potentialSafetyActions =>
       List.unmodifiable(_potentialSafetyActions);
 
-  List<ContingencyPlanEvent> contingencyEvents() =>
+  List<ContingencyPlanEvent> get contingencyEvents =>
       List.unmodifiable(_contingencyEvents);
 
   List<Widget> _contingencyEventsToWidget() => _contingencyEvents.isEmpty
@@ -134,6 +159,26 @@ class ContingencyPlanEvent {
         _activities = activities,
         _actionsTaken = actionsTaken;
 
+  @override
+  int get hashCode =>
+      eventDateAndTime.hashCode ^
+      _producerContactsUsed.hashCode ^
+      _receiverContactsUsed.hashCode ^
+      disturbancesIdentified.hashCode ^
+      _activities.hashCode ^
+      _actionsTaken.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is ContingencyPlanEvent) &&
+        other.eventDateAndTime == eventDateAndTime &&
+        listEquals(other.producerContactsUsed, _producerContactsUsed) &&
+        listEquals(other.receiverContactsUsed, _receiverContactsUsed) &&
+        other.disturbancesIdentified == disturbancesIdentified &&
+        listEquals(other.activities, activities) &&
+        listEquals(other.actionsTaken, _actionsTaken);
+  }
+
   ContingencyPlanEvent.fromJSON(Map<String, dynamic> json)
       : eventDateAndTime = DateTime.parse(json['eventDateAndTime']),
         _producerContactsUsed = List.from(json['_producerContactsUsed']),
@@ -155,15 +200,15 @@ class ContingencyPlanEvent {
         '_actionsTaken': _actionsTaken,
       };
 
-  List<String> producerContactsUsed() =>
+  List<String> get producerContactsUsed =>
       List.unmodifiable(_producerContactsUsed);
 
-  List<String> receiverContactsUsed() =>
+  List<String> get receiverContactsUsed =>
       List.unmodifiable(_receiverContactsUsed);
 
-  List<ContingencyActivity> activities() => List.unmodifiable(_activities);
+  List<ContingencyActivity> get activities => List.unmodifiable(_activities);
 
-  List<String> actionsTaken() => List.unmodifiable(_actionsTaken);
+  List<String> get actionsTaken => List.unmodifiable(_actionsTaken);
 
   Widget toWidget() {
     final List<Widget> widgetFields = [
@@ -212,6 +257,22 @@ class ContingencyActivity {
       @required this.personContacted,
       @required this.methodOfContact,
       @required this.instructionsGiven});
+
+  @override
+  int get hashCode =>
+      time.hashCode ^
+      personContacted.hashCode ^
+      methodOfContact.hashCode ^
+      instructionsGiven.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is ContingencyActivity) &&
+        other.time == time &&
+        other.personContacted == personContacted &&
+        other.methodOfContact == methodOfContact &&
+        other.instructionsGiven == instructionsGiven;
+  }
 
   ContingencyActivity.fromJSON(Map<String, dynamic> json)
       : time = TimeOfDay.fromDateTime(DateTime.parse(json['time'])),

--- a/app/lib/core/models/contingency_plan_info.dart
+++ b/app/lib/core/models/contingency_plan_info.dart
@@ -87,6 +87,20 @@ class ContingencyPlanInfo {
   List<ContingencyPlanEvent> get contingencyEvents =>
       List.unmodifiable(_contingencyEvents);
 
+  String _contingencyEventsToString() => _contingencyEvents.isEmpty
+      ? 'No events occurred during transport'
+      : _contingencyEvents.map((event) => event.toString()).toList().join(",");
+
+  String toString() =>
+      '''Goal Statement (company’s goal and purpose of the plan i.e avoid animal suffering): $goalStatement
+      Communication Plan (who should be contacted and who will initiate or permit the process?): $communicationPlan
+      Crisis contacts and links( general helpline, industry related links and websites): ${_crisisContacts.join(',')}
+      Expected Preparation Process (what should be done prior to loading animals?): $expectedPrepProcess
+      Standard Animal Monitoring: $standardAnimalMonitoring
+      Potential Hazard/Events/Challenges: ${_potentialHazards.join(',')}
+      Potential Actions to Ensure Human or Animal Safety: ${_potentialSafetyActions.join(',')}
+      Event Specific Plan(s): ${_contingencyEventsToString()}''';
+
   List<Widget> _contingencyEventsToWidget() => _contingencyEvents.isEmpty
       ? [
           ListTile(
@@ -210,6 +224,14 @@ class ContingencyPlanEvent {
 
   List<String> get actionsTaken => List.unmodifiable(_actionsTaken);
 
+  String toString() =>
+      '''Date and time of event: ${DateFormat("yyyy-MM-dd hh:mm").format(eventDateAndTime)}
+      Producer's emergency contacts used: ${_producerContactsUsed.join(",")}
+      Receiver's emergency contacts used: ${_receiverContactsUsed.join(",")}
+      Disturbances identified: $disturbancesIdentified
+      List of animal welfare related measures and actions taken(specific to the event): ${_actionsTaken.join(",")}
+      Carrier's communication activities: ${_activities.map((activity) => activity.toString()).toList().join(',')}''';
+
   Widget toWidget() {
     final List<Widget> widgetFields = [
       ListTile(
@@ -286,6 +308,11 @@ class ContingencyActivity {
         'methodOfContact': methodOfContact,
         'instructionsGiven': instructionsGiven,
       };
+
+  String toString() => '''Time of communication: $time
+  Who was contacted: $personContacted
+  Communication method used: $methodOfContact
+  What instructions were given and decisions made with the guidance of emergency contacts reached: $instructionsGiven''';
 
   Widget toWidget() {
     return Column(children: [

--- a/app/lib/core/models/delivery_info.dart
+++ b/app/lib/core/models/delivery_info.dart
@@ -1,4 +1,5 @@
 import 'package:app/core/models/receiver_info.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -17,6 +18,22 @@ class DeliveryInfo {
       @required List<CompromisedAnimal> compromisedAnimals,
       @required this.additionalWelfareConcerns})
       : _compromisedAnimals = compromisedAnimals;
+
+  @override
+  int get hashCode =>
+      recInfo.hashCode ^
+      arrivalDateAndTime.hashCode ^
+      _compromisedAnimals.hashCode ^
+      additionalWelfareConcerns.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is DeliveryInfo) &&
+        other.recInfo == recInfo &&
+        other.arrivalDateAndTime == arrivalDateAndTime &&
+        listEquals(other.compromisedAnimals, _compromisedAnimals) &&
+        other.additionalWelfareConcerns == additionalWelfareConcerns;
+  }
 
   DeliveryInfo.fromJSON(Map<String, dynamic> json)
       : recInfo = ReceiverInfo.fromJson(json['receiverInfo']),
@@ -37,7 +54,7 @@ class DeliveryInfo {
         'additionalWelfareConcerns': additionalWelfareConcerns,
       };
 
-  List<CompromisedAnimal> compromisedAnimals() =>
+  List<CompromisedAnimal> get compromisedAnimals =>
       List.unmodifiable(_compromisedAnimals);
 
   List<Widget> _compromisedAnimalsToWidget() => _compromisedAnimals.isEmpty

--- a/app/lib/core/models/delivery_info.dart
+++ b/app/lib/core/models/delivery_info.dart
@@ -65,6 +65,19 @@ class DeliveryInfo {
         ]
       : _compromisedAnimals.map((animals) => animals.toWidget()).toList();
 
+  String _compromisedAnimalsToString() => _compromisedAnimals.isEmpty
+      ? 'N/A'
+      : _compromisedAnimals
+          .map((animal) => animal.toString())
+          .toList()
+          .join(",");
+
+  String toString() => '''$recInfo
+  Date and time of arrival: ${DateFormat("yyyy-MM-dd hh:mm").format(arrivalDateAndTime)}
+  All animals arrived in good condition?: ${_compromisedAnimals.isEmpty ? 'Yes' : 'No'}
+  Description of transport related conditions and actions taken to address prior to arrival: ${_compromisedAnimalsToString()}
+  Additional animal welfare concerns for the consignee to be aware of?: $additionalWelfareConcerns''';
+
   Widget toWidget() {
     final List<Widget> fields = [
       ListTile(

--- a/app/lib/core/models/feed_water_rest_info.dart
+++ b/app/lib/core/models/feed_water_rest_info.dart
@@ -44,6 +44,15 @@ class FeedWaterRestInfo {
         listEquals(other.fwrEvents, _fwrEvents);
   }
 
+  String _fwrEventsToString() => _fwrEvents.isEmpty
+      ? 'No events occurred during transport'
+      : _fwrEvents.map((event) => event.toString()).toList().join(",");
+
+  String toString() =>
+      '''Last access to feed, water and rest (FWR) prior to loading:
+      Date and time: ${DateFormat("yyyy-MM-dd hh:mm").format(lastFwrDate)}, Place: $lastFwrLocation
+      If FWR was provided during transport: $_fwrEventsToString()''';
+
   List<Widget> _fwrEventsToWidget() => _fwrEvents.isEmpty
       ? [
           ListTile(
@@ -117,6 +126,11 @@ class FeedWaterRestEvent {
         other.lastFwrLocation == lastFwrLocation &&
         other.fwrProvidedOnboard == fwrProvidedOnboard;
   }
+
+  String toString() =>
+      '''Animals unloaded?: ${animalsWereUnloaded ? 'Yes' : 'No'}
+      Date and time: ${DateFormat("yyyy-MM-dd hh:mm").format(fwrTime)}, Place: $lastFwrLocation
+      Provided onboard?: ${fwrProvidedOnboard ? 'Yes' : 'No'}''';
 
   Widget toWidget() {
     return Column(children: [

--- a/app/lib/core/models/loading_vehicle_info.dart
+++ b/app/lib/core/models/loading_vehicle_info.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -36,7 +37,26 @@ class LoadingVehicleInfo {
         '_animalsLoaded':
             _animalsLoaded.map((animalLoaded) => animalLoaded.toJSON()).toList()
       };
-  List<AnimalGroup> animalsLoaded() => List.unmodifiable(_animalsLoaded);
+
+  @override
+  int get hashCode =>
+      dateAndTimeLoaded.hashCode ^
+      loadingArea.hashCode ^
+      loadingDensity.hashCode ^
+      animalsPerLoadingArea.hashCode ^
+      _animalsLoaded.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is LoadingVehicleInfo) &&
+        other.dateAndTimeLoaded == dateAndTimeLoaded &&
+        other.loadingArea == loadingArea &&
+        other.loadingDensity == loadingDensity &&
+        other.animalsPerLoadingArea == animalsPerLoadingArea &&
+        other.animalsLoaded == _animalsLoaded;
+  }
+
+  List<AnimalGroup> get animalsLoaded => List.unmodifiable(_animalsLoaded);
 
   List<String> animalSpeciesLoaded() {
     return List.unmodifiable(
@@ -95,6 +115,30 @@ class AnimalGroup {
       : _compromisedAnimals = compromisedAnimals,
         _specialNeedsAnimals = specialNeedsAnimals;
 
+  @override
+  int get hashCode =>
+      species.hashCode ^
+      groupAge.hashCode ^
+      approximateWeight.hashCode ^
+      animalPurpose.hashCode ^
+      numberAnimals.hashCode ^
+      animalsFitForTransport.hashCode ^
+      _compromisedAnimals.hashCode ^
+      _specialNeedsAnimals.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is AnimalGroup) &&
+        other.species == species &&
+        other.groupAge == groupAge &&
+        other.approximateWeight == approximateWeight &&
+        other.animalPurpose == animalPurpose &&
+        other.numberAnimals == numberAnimals &&
+        other.animalsFitForTransport == animalsFitForTransport &&
+        listEquals(other.compromisedAnimals, _compromisedAnimals) &&
+        listEquals(other.specialNeedsAnimals, _specialNeedsAnimals);
+  }
+
   AnimalGroup.fromJSON(Map<String, dynamic> json)
       : species = json['species'],
         groupAge = json['groupAge'],
@@ -126,10 +170,10 @@ class AnimalGroup {
             .toList(),
       };
 
-  List<CompromisedAnimal> compromisedAnimals() =>
+  List<CompromisedAnimal> get compromisedAnimals =>
       List.unmodifiable(_compromisedAnimals);
 
-  List<CompromisedAnimal> specialNeedsAnimals() =>
+  List<CompromisedAnimal> get specialNeedsAnimals =>
       List.unmodifiable(_specialNeedsAnimals);
 
   List<Widget> _compromisedAnimalsToWidget() => _compromisedAnimals.isEmpty
@@ -212,6 +256,17 @@ class CompromisedAnimal {
   CompromisedAnimal(
       {@required this.animalDescription,
       @required this.measuresTakenToCareForAnimal});
+
+  @override
+  int get hashCode =>
+      animalDescription.hashCode ^ measuresTakenToCareForAnimal.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is CompromisedAnimal) &&
+        other.animalDescription == animalDescription &&
+        other.measuresTakenToCareForAnimal == measuresTakenToCareForAnimal;
+  }
 
   CompromisedAnimal.fromJSON(Map<String, dynamic> json)
       : animalDescription = json['animalDescription'],

--- a/app/lib/core/models/loading_vehicle_info.dart
+++ b/app/lib/core/models/loading_vehicle_info.dart
@@ -58,10 +58,15 @@ class LoadingVehicleInfo {
 
   List<AnimalGroup> get animalsLoaded => List.unmodifiable(_animalsLoaded);
 
-  List<String> animalSpeciesLoaded() {
-    return List.unmodifiable(
-        _animalsLoaded.map((animalGroup) => animalGroup.species).toList());
-  }
+  List<String> get animalSpeciesLoaded => List.unmodifiable(
+      _animalsLoaded.map((animalGroup) => animalGroup.species).toList());
+
+  String toString() =>
+      '''Date and time of loading: ${DateFormat("yyyy-MM-dd hh:mm").format(dateAndTimeLoaded)}
+      Floor or container area available to animals (m2 or ft2): $loadingArea
+      Loading density: $loadingDensity
+      Animals per floor area (Kg/m2 or lbs/ft2): $animalsPerLoadingArea
+      Animals loaded: ${_animalsLoaded.map((group) => group.toString()).join('\n')}''';
 
   Widget toWidget() {
     final List<Widget> fields = [
@@ -176,6 +181,29 @@ class AnimalGroup {
   List<CompromisedAnimal> get specialNeedsAnimals =>
       List.unmodifiable(_specialNeedsAnimals);
 
+  String _compromisedAnimalsToString() => _compromisedAnimals.isEmpty
+      ? 'N/A'
+      : _compromisedAnimals
+          .map((animal) => animal.toString())
+          .toList()
+          .join(",");
+
+  String _specialNeedsAnimalsToString() => _specialNeedsAnimals.isEmpty
+      ? 'N/A'
+      : _specialNeedsAnimals
+          .map((animal) => animal.toString())
+          .toList()
+          .join(",");
+
+  String toString() => '''Animal(s) description:
+  Species: $species, Group age: $groupAge, Approximate weight: $approximateWeight
+  Purpose: $animalPurpose, Number of animals: $numberAnimals
+  Are all animals fit for transport?: ${animalsFitForTransport ? 'Yes' : 'No'}
+  Number of compromised animals loaded: ${_compromisedAnimals.length}
+  Compromised animal(s), identification description and measures taken: ${_compromisedAnimalsToString()}
+  Number of animal(s) with special needs: ${_specialNeedsAnimals.length}
+  Special needs animal(s), identification description and measures taken: ${_specialNeedsAnimalsToString()}''';
+
   List<Widget> _compromisedAnimalsToWidget() => _compromisedAnimals.isEmpty
       ? [
           ListTile(
@@ -276,6 +304,9 @@ class CompromisedAnimal {
         'animalDescription': animalDescription,
         'measuresTakenToCareForAnimal': measuresTakenToCareForAnimal,
       };
+
+  String toString() => '''$animalDescription
+  $measuresTakenToCareForAnimal''';
 
   Widget toWidget() => ListTile(
       visualDensity: VisualDensity(horizontal: 0, vertical: -2),

--- a/app/lib/core/models/receiver_info.dart
+++ b/app/lib/core/models/receiver_info.dart
@@ -41,6 +41,13 @@ class ReceiverInfo {
         'receiverContactInfo': receiverContactInfo
       };
 
+  String toString() => '''Receiving company name: $receiverCompanyName
+  Representative name: $receiverName
+  Account identification number (Optional): ${accountId.isPresent() ? accountId.get() : "N/A"}
+  Destination and Premises Identification number (PID): $destinationLocationId, Name: $destinationLocationName
+  Address: $destinationAddress
+  Receiver’s Contact number in case of emergency: $receiverContactInfo''';
+
   Widget toWidget() {
     return Column(children: [
       ListTile(

--- a/app/lib/core/models/shipper_info.dart
+++ b/app/lib/core/models/shipper_info.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'address.dart';
 
 @immutable
@@ -53,6 +54,12 @@ class ShipperInfo {
         other.departureAddress == departureAddress &&
         other.shipperContactInfo == shipperContactInfo;
   }
+
+  String toString() => '''Name: $shipperName
+  The shipper is the owner of the animals loaded in the vehicle?: ${shipperIsAnimalOwner ? 'Yes' : 'No'}
+  Departure Premises Identification number (PID): $departureLocationId, Name: $departureLocationName
+  Address: $departureAddress
+  Shipper’s Contact information in case of emergency: $shipperContactInfo''';
 
   Widget toWidget() {
     return Column(children: [

--- a/app/lib/core/models/transporter_info.dart
+++ b/app/lib/core/models/transporter_info.dart
@@ -104,6 +104,17 @@ class TransporterInfo {
         'trainingExpiryDate': trainingExpiryDate,
       };
 
+  String toString() => '''Name of transporting company: $companyName
+  Address: $companyAddress
+  Driver(s) name(s): ${driverNames.join(",")}
+  Province and License Plate number of the conveyance transporting the animals: $vehicleProvince, $vehicleLicensePlate
+  (including trailer): $trailerProvince, $trailerProvince
+  Conveyance or container last cleaned and disinfected date and time: ${DateFormat("yyyy-MM-dd hh:mm").format(dateLastCleaned)}
+  Place: $addressLastCleanedAt
+  Driver(s) have been briefed on the contingency plan?: ${driversAreBriefed ? 'Yes' : 'No'}
+  Driver(s) have received humane transport training?: ${driversHaveTraining ? 'Yes' : 'No'}
+  Training type: $trainingType, Expiry date: ${DateFormat("yyyy-MM-dd hh:mm").format(trainingExpiryDate)}''';
+
   Widget toWidget() {
     return Column(children: [
       ListTile(

--- a/app/lib/ui/widgets/atr_preview_card.dart
+++ b/app/lib/ui/widgets/atr_preview_card.dart
@@ -18,7 +18,7 @@ class ATRPreviewCard extends StatelessWidget {
       title:
           Text('Delivery for ${atr.deliveryInfo.recInfo.receiverCompanyName}'),
       subtitle: Text(
-          '${DateFormat("yyyy-MM-dd hh:mm").format(atr.vehicleInfo.dateAndTimeLoaded)} ${atr.vehicleInfo.animalSpeciesLoaded().join(',')}'),
+          '${DateFormat("yyyy-MM-dd hh:mm").format(atr.vehicleInfo.dateAndTimeLoaded)} ${atr.vehicleInfo.animalSpeciesLoaded.join(',')}'),
       onTap: onTap,
     )));
   }


### PR DESCRIPTION
In this PR I have done:
1. Added back the `toString()` methods for tests. Can also be used when generating the PDF until we format it.
2. Added equality and hashcode overloads for tests. These might be a little off, but they will definitely be caught in tests because of `toString()`.
3. Made a bunch of functions into dart syntactic sugar getters