### PR TITLE
Add deliver info to editing screen

### DIFF
--- a/app/lib/core/models/receiver_info.dart
+++ b/app/lib/core/models/receiver_info.dart
@@ -22,6 +22,28 @@ class ReceiverInfo {
       @required this.destinationAddress,
       @required this.receiverContactInfo});
 
+  @override
+  int get hashCode =>
+      receiverCompanyName.hashCode ^
+      receiverName.hashCode ^
+      accountId.hashCode ^
+      destinationLocationId.hashCode ^
+      destinationLocationName.hashCode ^
+      destinationAddress.hashCode ^
+      receiverContactInfo.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is ReceiverInfo) &&
+        other.receiverCompanyName == receiverCompanyName &&
+        other.receiverName == receiverName &&
+        other.accountId == accountId &&
+        other.destinationLocationId == destinationLocationId &&
+        other.destinationLocationName == destinationLocationName &&
+        other.receiverContactInfo == receiverContactInfo &&
+        other.destinationAddress == destinationAddress;
+  }
+
   ReceiverInfo.fromJson(Map<String, dynamic> json)
       : receiverCompanyName = json['receiverCompanyName'],
         receiverName = json['receiverName'],

--- a/app/lib/core/utilities/optional.dart
+++ b/app/lib/core/utilities/optional.dart
@@ -19,4 +19,12 @@ class Optional<T> {
 
   T get() =>
       isPresent() ? _optional : throw Exception("The Optional value is null!");
+
+  @override
+  int get hashCode => _optional.hashCode;
+
+  @override
+  bool operator ==(other) {
+    return (other is Optional) && other._optional == _optional;
+  }
 }

--- a/app/lib/test/helper/test_receiver_info_expectations.dart
+++ b/app/lib/test/helper/test_receiver_info_expectations.dart
@@ -1,0 +1,18 @@
+import 'package:app/core/models/receiver_info.dart';
+import 'package:app/test/helper/test_address_expectations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void verifyReceiverInfoIsShown(ReceiverInfo infoExpected) {
+  expect(find.text(infoExpected.receiverCompanyName), findsOneWidget);
+  expect(find.text(infoExpected.receiverName), findsOneWidget);
+  expect(
+      find.text(infoExpected.accountId.isPresent()
+          ? infoExpected.accountId.get()
+          : ""),
+      findsOneWidget);
+  expect(find.text(infoExpected.destinationLocationId), findsOneWidget);
+  expect(find.text(infoExpected.destinationLocationName), findsOneWidget);
+  expect(find.text(infoExpected.receiverContactInfo), findsOneWidget);
+
+  verifyAddressIsShown(infoExpected.destinationAddress);
+}

--- a/app/lib/ui/views/active/atr_editing_screen.dart
+++ b/app/lib/ui/views/active/atr_editing_screen.dart
@@ -1,4 +1,5 @@
 import 'package:app/core/models/animal_transport_record.dart';
+import 'package:app/core/models/delivery_info.dart';
 import 'package:app/core/models/feed_water_rest_info.dart';
 import 'package:app/core/models/loading_vehicle_info.dart';
 import 'package:app/core/models/shipper_info.dart';
@@ -7,6 +8,7 @@ import 'package:app/core/services/dialog/dialog_service.dart';
 import 'package:app/core/services/navigation/nav_service.dart';
 import 'package:app/core/services/service_locator.dart';
 import 'package:app/core/view_models/active_screen_view_model.dart';
+import 'package:app/ui/views/active/form_field/delivery_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/loading_vehicle_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/shipper_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/transporter_info_form_field.dart';
@@ -31,12 +33,13 @@ class ATREditingScreen extends StatefulWidget {
 
 class _ATREditingScreenState extends State<ATREditingScreen> {
   AnimalTransportRecord _replacementAtr;
+  final List<ExpansionListItem> _atrFormFieldsWrapper = [];
 
   ShipperInfoFormField _shipperInfoField;
   TransporterInfoFormField _transporterInfoFormField;
   FeedWaterRestInfoFormField _feedWaterRestInfoFormField;
   LoadingVehicleInfoFormField _loadingVehicleInfoFormField;
-  final List<ExpansionListItem> _atrFormFieldsWrapper = [];
+  DeliveryInfoFormField _deliveryInfoFormField;
 
   @override
   void initState() {
@@ -59,6 +62,11 @@ class _ATREditingScreenState extends State<ATREditingScreen> {
         initialInfo: _replacementAtr.vehicleInfo,
         onSaved: (LoadingVehicleInfo newInfo) =>
             _replacementAtr = _replacementAtr.withVehicleInfo(newInfo));
+    _deliveryInfoFormField = DeliveryInfoFormField(
+      initialInfo: _replacementAtr.deliveryInfo,
+      onSaved: (DeliveryInfo newInfo) =>
+          _replacementAtr = _replacementAtr.withDeliveryInfo(newInfo),
+    );
 
     _atrFormFieldsWrapper.addAll([
       ExpansionListItem(
@@ -72,7 +80,10 @@ class _ATREditingScreenState extends State<ATREditingScreen> {
           headerValue: _feedWaterRestInfoFormField.title),
       ExpansionListItem(
           expandedValue: _loadingVehicleInfoFormField,
-          headerValue: _loadingVehicleInfoFormField.title)
+          headerValue: _loadingVehicleInfoFormField.title),
+      ExpansionListItem(
+          expandedValue: _deliveryInfoFormField,
+          headerValue: _deliveryInfoFormField.title)
     ]);
   }
 

--- a/app/lib/ui/views/active/form_field/delivery_info_form_field.dart
+++ b/app/lib/ui/views/active/form_field/delivery_info_form_field.dart
@@ -1,0 +1,102 @@
+import 'package:app/core/models/delivery_info.dart';
+import 'package:app/core/models/loading_vehicle_info.dart';
+import 'package:app/core/models/receiver_info.dart';
+import 'package:app/core/utilities/optional.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_compromised_animal_form_field.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
+import 'package:app/ui/views/active/form_field/compromised_animal_form_field.dart';
+import 'package:app/ui/views/active/form_field/receiver_info_form_field.dart';
+import 'package:app/ui/views/active/form_field/string_form_field.dart';
+import 'package:app/ui/widgets/utility/date_time_picker.dart';
+import 'package:flutter/material.dart';
+
+class DeliveryInfoFormField extends StatefulWidget {
+  final Function(DeliveryInfo info) onSaved;
+  final DeliveryInfo initialInfo;
+  final String title = "Delivery Information";
+
+  // Use the form key to save all the fields of this form
+  final formKey = GlobalKey<FormState>();
+
+  DeliveryInfoFormField(
+      {Key key, @required this.initialInfo, @required this.onSaved})
+      : super(key: key);
+
+  @override
+  _DeliveryInfoFormFieldState createState() => _DeliveryInfoFormFieldState();
+}
+
+class _DeliveryInfoFormFieldState extends State<DeliveryInfoFormField> {
+  ReceiverInfo _receiverInfo;
+  DateTime _arrivalDateAndTime;
+  List<CompromisedAnimal> _compromisedAnimals;
+  String _additionalWelfareConcerns;
+
+  ReceiverInfoFormField _receiverInfoFormField;
+  DynamicFormField<CompromisedAnimal, CompromisedAnimalFormField>
+      _compromisedAnimalsFormField;
+
+  @override
+  void initState() {
+    _receiverInfo = widget.initialInfo.recInfo;
+    _arrivalDateAndTime = widget.initialInfo.arrivalDateAndTime;
+    _compromisedAnimals = widget.initialInfo.compromisedAnimals;
+    _additionalWelfareConcerns = widget.initialInfo.additionalWelfareConcerns;
+    _receiverInfoFormField = ReceiverInfoFormField(
+        initialInfo: _receiverInfo,
+        onSaved: (ReceiverInfo changed) {
+          _receiverInfo = changed;
+          _saveAll();
+        });
+    _compromisedAnimalsFormField = dynamicCompromisedAnimalFormField(
+        initialList: _compromisedAnimals,
+        titles: "Compromised animal",
+        onSaved: (List<CompromisedAnimal> changed) {
+          _compromisedAnimals = changed;
+          _saveAll();
+        });
+    super.initState();
+  }
+
+  void _saveAll() => widget.onSaved(DeliveryInfo(
+      recInfo: _receiverInfo,
+      arrivalDateAndTime: _arrivalDateAndTime,
+      compromisedAnimals: _compromisedAnimals,
+      additionalWelfareConcerns: _additionalWelfareConcerns));
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: widget.formKey,
+      child: Column(children: [
+        ListTile(
+          title: Text("Receiver Info"),
+          subtitle: _receiverInfoFormField,
+        ),
+        ListTile(
+            title: Text("Date and time of arrival"),
+            subtitle: dateTimePicker(
+                initialDate: _arrivalDateAndTime,
+                onSaved: (String changed) {
+                  _arrivalDateAndTime = DateTime.parse(changed);
+                  _saveAll();
+                })),
+        ListTile(
+            title: Text(
+                "If any animals did not arrive in good condition\nDescription of transport related conditions and actions taken to address prior to arrival")),
+        _compromisedAnimalsFormField,
+        StringFormField(
+            initial: _additionalWelfareConcerns,
+            isMultiline: true,
+            title:
+                "Additional animal welfare concerns for the consignee to be aware of?",
+            onSaved: (String changed) {
+              _additionalWelfareConcerns = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        RaisedButton(child: Text("Save"), onPressed: _saveAll)
+      ]),
+    );
+  }
+}

--- a/app/lib/ui/views/active/form_field/receiver_info_form_field.dart
+++ b/app/lib/ui/views/active/form_field/receiver_info_form_field.dart
@@ -1,0 +1,124 @@
+import 'package:app/core/models/address.dart';
+import 'package:app/core/models/receiver_info.dart';
+import 'package:app/core/utilities/optional.dart';
+import 'package:app/ui/views/active/form_field/string_form_field.dart';
+import 'package:flutter/material.dart';
+
+import 'address_form_field.dart';
+
+class ReceiverInfoFormField extends StatefulWidget {
+  final Function(ReceiverInfo info) onSaved;
+  final ReceiverInfo initialInfo;
+
+  // Use the form key to save all the fields of this form
+  final formKey = GlobalKey<FormState>();
+
+  ReceiverInfoFormField(
+      {Key key, @required this.initialInfo, @required this.onSaved})
+      : super(key: key);
+
+  @override
+  _ReceiverInfoFormFieldState createState() => _ReceiverInfoFormFieldState();
+}
+
+class _ReceiverInfoFormFieldState extends State<ReceiverInfoFormField> {
+  String _receiverCompanyName;
+  String _receiverName;
+  Optional<String> _accountId;
+  String _destinationLocationId;
+  String _destinationLocationName;
+  Address _destinationAddress;
+  String _receiverContactInfo;
+
+  AddressFormField _destinationAddressFormField;
+
+  @override
+  void initState() {
+    _receiverCompanyName = widget.initialInfo.receiverCompanyName;
+    _receiverName = widget.initialInfo.receiverName;
+    _accountId = widget.initialInfo.accountId;
+    _destinationLocationId = widget.initialInfo.destinationLocationId;
+    _destinationLocationName = widget.initialInfo.destinationLocationName;
+    _destinationAddress = widget.initialInfo.destinationAddress;
+    _receiverContactInfo = widget.initialInfo.receiverContactInfo;
+    _destinationAddressFormField = AddressFormField(
+        initialAddr: _destinationAddress,
+        onSaved: (Address changed) {
+          _destinationAddress = changed;
+          _saveAll();
+        });
+    super.initState();
+  }
+
+  void _saveAll() => widget.onSaved(ReceiverInfo(
+      receiverCompanyName: _receiverCompanyName,
+      receiverName: _receiverName,
+      accountId: _accountId,
+      destinationLocationId: _destinationLocationId,
+      destinationLocationName: _destinationLocationName,
+      destinationAddress: _destinationAddress,
+      receiverContactInfo: _receiverContactInfo));
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: widget.formKey,
+      child: Column(children: [
+        StringFormField(
+            initial: _receiverCompanyName,
+            title: "Receiving company name",
+            onSaved: (String changed) {
+              _receiverCompanyName = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        StringFormField(
+            initial: _receiverName,
+            title: "Representative name",
+            onSaved: (String changed) {
+              _receiverName = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        StringFormField(
+            initial: _accountId.isPresent() ? _accountId.get() : "",
+            title:
+                "Account identification number of the consignee in the database of the responsible administrator (Optional)",
+            onSaved: (String changed) {
+              _accountId =
+                  changed == "" ? Optional.empty() : Optional.of(changed);
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        StringFormField(
+            initial: _destinationLocationId,
+            title: "Destination and Premises Identification number (PID)",
+            onSaved: (String changed) {
+              _destinationLocationId = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        StringFormField(
+            initial: _destinationLocationName,
+            title: "Destination and Premises name",
+            onSaved: (String changed) {
+              _destinationLocationName = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        ListTile(
+          title: Text("Destination and Premises address"),
+          subtitle: _destinationAddressFormField,
+        ),
+        StringFormField(
+            initial: _receiverContactInfo,
+            title: "Receiver’s Contact number in case of emergency",
+            onSaved: (String changed) {
+              _receiverContactInfo = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+      ]),
+    );
+  }
+}

--- a/app/test/ui/views/active/atr_editing_screen_test.dart
+++ b/app/test/ui/views/active/atr_editing_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:app/core/services/navigation/nav_service.dart';
 import 'package:app/core/view_models/active_screen_view_model.dart';
 import 'package:app/test/test_animal_transport_record.dart';
 import 'package:app/ui/views/active/atr_editing_screen.dart';
+import 'package:app/ui/views/active/form_field/delivery_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/fwr_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/loading_vehicle_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/shipper_info_form_field.dart';
@@ -59,6 +60,11 @@ void main() {
         (WidgetTester tester) async {
       await pumpATREditingScreen(tester, testAnimalTransportRecord());
       expect(find.byType(LoadingVehicleInfoFormField), findsOneWidget);
+    });
+
+    testWidgets('has delivery info form field', (WidgetTester tester) async {
+      await pumpATREditingScreen(tester, testAnimalTransportRecord());
+      expect(find.byType(DeliveryInfoFormField), findsOneWidget);
     });
 
     testWidgets('shows submit button', (WidgetTester tester) async {

--- a/app/test/ui/views/active/form_field/delivery_info_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/delivery_info_form_field_test.dart
@@ -1,0 +1,110 @@
+import 'package:app/core/models/delivery_info.dart';
+import 'package:app/core/models/receiver_info.dart';
+import 'package:app/core/utilities/optional.dart';
+import 'package:app/test/helper/test_compromised_animal_expectations.dart';
+import 'package:app/test/helper/test_receiver_info_expectations.dart';
+import 'package:app/test/test_animal_transport_record.dart';
+import 'package:app/ui/views/active/form_field/delivery_info_form_field.dart';
+import 'package:date_time_picker/date_time_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  void verifyInformationIsShown(DeliveryInfo infoExpected) {
+    infoExpected.compromisedAnimals.forEach((animal) {
+      verifyCompromisedAnimalInfoIsShown(animal);
+    });
+    // Date and time are in separate fields
+    expect(
+        find.text(
+            DateFormat('MMM d, yyyy').format(infoExpected.arrivalDateAndTime)),
+        findsOneWidget);
+    expect(
+        find.text(DateFormat('HH:mm').format(infoExpected.arrivalDateAndTime)),
+        findsOneWidget);
+    verifyReceiverInfoIsShown(infoExpected.recInfo);
+    expect(find.text(infoExpected.additionalWelfareConcerns), findsOneWidget);
+  }
+
+  Future<void> pumpDeliveryInfoFormField(WidgetTester tester,
+          DeliveryInfo testInfo, Function(DeliveryInfo) callback) async =>
+      tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+              body: SingleChildScrollView(
+                  child: Container(
+        child: DeliveryInfoFormField(initialInfo: testInfo, onSaved: callback),
+      )))));
+
+  group('Delivery Info Form Field', () {
+    testWidgets('shows right information', (WidgetTester tester) async {
+      final testDeliveryInfo = DeliveryInfo(
+          recInfo: ReceiverInfo(
+              receiverCompanyName: "Temp Company",
+              receiverName: "John Caddy",
+              accountId: Optional.of("789er"),
+              destinationLocationId: "uioet483u9",
+              destinationLocationName: "Farmville",
+              destinationAddress: testAddress(),
+              receiverContactInfo: "By email: test@gmail.com"),
+          arrivalDateAndTime: DateTime.parse("2023-11-14 14:21"),
+          compromisedAnimals: [],
+          additionalWelfareConcerns: "None");
+      await pumpDeliveryInfoFormField(tester, testDeliveryInfo, (_) {
+        // Do nothing for test
+      });
+      verifyInformationIsShown(testDeliveryInfo);
+    });
+
+    testWidgets('shows save button', (WidgetTester tester) async {
+      final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
+      await pumpDeliveryInfoFormField(tester, testDeliveryInfo(), (_) {
+        // Do nothing for test
+      });
+      await tester.ensureVisible(saveButtonFinder);
+      expect(saveButtonFinder, findsOneWidget);
+    });
+
+    testWidgets('calls onSaved when save button pressed',
+        (WidgetTester tester) async {
+      final testInfo = testDeliveryInfo();
+      final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
+      DeliveryInfo callbackInfo;
+      final onSavedCallback = (DeliveryInfo info) => callbackInfo = info;
+
+      await pumpDeliveryInfoFormField(tester, testInfo, onSavedCallback);
+      await tester.ensureVisible(saveButtonFinder);
+      await tester.tap(saveButtonFinder);
+      await tester.pumpAndSettle();
+      expect(callbackInfo, testInfo);
+    });
+
+    testWidgets(
+        'calls onSaved with edited compromised animal info when save button pressed',
+        (WidgetTester tester) async {
+      final testDescription = "Chicken bad leg";
+      final editedDescription = "Turkey bad leg";
+      final testInfo = testDeliveryInfo(compromisedAnimals: [
+        testCompromisedAnimal(animalDescription: testDescription)
+      ]);
+      final editedInfo = testDeliveryInfo(compromisedAnimals: [
+        testCompromisedAnimal(animalDescription: editedDescription)
+      ]);
+
+      DeliveryInfo callback;
+      final onSaved = (DeliveryInfo changed) => callback = changed;
+      final fieldFinder = find.widgetWithText(TextFormField, testDescription);
+      final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
+
+      await pumpDeliveryInfoFormField(tester, testInfo, onSaved);
+      // Edit text
+      await tester.ensureVisible(fieldFinder);
+      await tester.enterText(fieldFinder, editedDescription);
+      await tester.pumpAndSettle();
+      // Save
+      await tester.ensureVisible(saveButtonFinder);
+      await tester.tap(saveButtonFinder);
+      await tester.pumpAndSettle();
+      expect(callback, editedInfo);
+    });
+  });
+}

--- a/app/test/ui/views/active/form_field/receiver_info_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/receiver_info_form_field_test.dart
@@ -1,0 +1,57 @@
+import 'package:app/core/models/receiver_info.dart';
+import 'package:app/core/utilities/optional.dart';
+import 'package:app/test/helper/test_receiver_info_expectations.dart';
+import 'package:app/test/test_animal_transport_record.dart';
+import 'package:app/ui/views/active/form_field/receiver_info_form_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpReceiverInfoFormField(WidgetTester tester,
+          ReceiverInfo initial, Function(ReceiverInfo) onSaved) async =>
+      tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+              body: SingleChildScrollView(
+        child: ReceiverInfoFormField(
+          initialInfo: initial,
+          onSaved: onSaved,
+        ),
+      ))));
+
+  group('Receiver Info Form Field', () {
+    testWidgets('shows right information', (WidgetTester tester) async {
+      final testReceiverInfo = ReceiverInfo(
+          receiverCompanyName: "Tester Company",
+          receiverName: "Kelly Holds",
+          accountId: Optional.empty(),
+          destinationLocationId: "ert456",
+          destinationLocationName: "Tester Company Farms",
+          destinationAddress: testAddress(),
+          receiverContactInfo: "By phone: 3061111111");
+      await pumpReceiverInfoFormField(tester, testReceiverInfo, (_) {
+        // do nothing for test
+      });
+      verifyReceiverInfoIsShown(testReceiverInfo);
+    });
+
+    testWidgets('onSaved called when account ID info edited',
+        (WidgetTester tester) async {
+      final testAccountId = Optional<String>.empty();
+      final editedAccountId = Optional.of("123");
+      ReceiverInfo callback;
+      final onSavedCallback = (ReceiverInfo changed) => callback = changed;
+      final fieldFinder = find.widgetWithText(TextFormField, "");
+      final editedFieldFinder = find.widgetWithText(TextFormField, "123");
+      final testRecInfo = testReceiverInfo(accountId: testAccountId);
+      final editedRecInfo = testReceiverInfo(accountId: editedAccountId);
+
+      await pumpReceiverInfoFormField(tester, testRecInfo, onSavedCallback);
+      await tester.enterText(fieldFinder, "123");
+      await tester.pumpAndSettle();
+      // expect was saved
+      expect(callback, editedRecInfo);
+      // expect edited text visible
+      expect(editedFieldFinder, findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Related to #134 .

In this PR I have:
1. Added the Receiver Info form field
2. Added the Delivery info form field
3. Added missing equality overloads to receiver info and optional types

***

Changes look like:


https://user-images.githubusercontent.com/32527219/109406743-4c9b1880-7941-11eb-975d-f8a0f60bd1eb.mov

