### PR TITLE
Add ack and contingency info editing screen

### DIFF
--- a/app/lib/core/models/contingency_plan_info.dart
+++ b/app/lib/core/models/contingency_plan_info.dart
@@ -94,7 +94,7 @@ class ContingencyPlanInfo {
   String toString() =>
       '''Goal Statement (company’s goal and purpose of the plan i.e avoid animal suffering): $goalStatement
       Communication Plan (who should be contacted and who will initiate or permit the process?): $communicationPlan
-      Crisis contacts and links( general helpline, industry related links and websites): ${_crisisContacts.join(',')}
+      Crisis contacts and links (general helpline, industry related links and websites): ${_crisisContacts.join(',')}
       Expected Preparation Process (what should be done prior to loading animals?): $expectedPrepProcess
       Standard Animal Monitoring: $standardAnimalMonitoring
       Potential Hazard/Events/Challenges: ${_potentialHazards.join(',')}

--- a/app/lib/test/helper/test_contingency_activity_expectations.dart
+++ b/app/lib/test/helper/test_contingency_activity_expectations.dart
@@ -1,0 +1,11 @@
+import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/ui/widgets/utility/date_time_picker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void verifyContingencyActivityShown(ContingencyActivity infoExpected) {
+  expect(
+      find.text(convertTimeOfDayToString(infoExpected.time)), findsOneWidget);
+  expect(find.text(infoExpected.personContacted), findsOneWidget);
+  expect(find.text(infoExpected.methodOfContact), findsOneWidget);
+  expect(find.text(infoExpected.instructionsGiven), findsOneWidget);
+}

--- a/app/lib/test/helper/test_contingency_plan_event_expectations.dart
+++ b/app/lib/test/helper/test_contingency_plan_event_expectations.dart
@@ -1,0 +1,23 @@
+import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/test/helper/test_contingency_activity_expectations.dart';
+import 'package:date_time_picker/date_time_picker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void verifyContingencyPlanEventShown(ContingencyPlanEvent infoExpected) {
+  // Date and time are in separate fields
+  expect(
+      find.text(
+          DateFormat('MMM d, yyyy').format(infoExpected.eventDateAndTime)),
+      findsOneWidget);
+  expect(find.text(DateFormat('HH:mm').format(infoExpected.eventDateAndTime)),
+      findsOneWidget);
+  infoExpected.producerContactsUsed
+      .forEach((contact) => expect(find.text(contact), findsOneWidget));
+  infoExpected.receiverContactsUsed
+      .forEach((contact) => expect(find.text(contact), findsOneWidget));
+  expect(find.text(infoExpected.disturbancesIdentified), findsOneWidget);
+  infoExpected.activities
+      .forEach((activity) => verifyContingencyActivityShown(activity));
+  infoExpected.actionsTaken
+      .forEach((action) => expect(find.text(action), findsOneWidget));
+}

--- a/app/lib/test/test_animal_transport_record.dart
+++ b/app/lib/test/test_animal_transport_record.dart
@@ -227,7 +227,8 @@ testContingencyActivity(
         String methodOfContact,
         String instructionsGiven}) =>
     ContingencyActivity(
-        time: time ?? TimeOfDay.now(),
+        time:
+            time ?? TimeOfDay.fromDateTime(DateTime.parse("2021-02-03 13:01")),
         personContacted: personContacted ?? "Receiver",
         methodOfContact: methodOfContact ?? "Phone call",
         instructionsGiven: instructionsGiven ?? "Instructions");

--- a/app/lib/ui/views/active/atr_editing_screen.dart
+++ b/app/lib/ui/views/active/atr_editing_screen.dart
@@ -1,3 +1,4 @@
+import 'package:app/core/models/acknowledgement_info.dart';
 import 'package:app/core/models/animal_transport_record.dart';
 import 'package:app/core/models/delivery_info.dart';
 import 'package:app/core/models/feed_water_rest_info.dart';
@@ -8,6 +9,7 @@ import 'package:app/core/services/dialog/dialog_service.dart';
 import 'package:app/core/services/navigation/nav_service.dart';
 import 'package:app/core/services/service_locator.dart';
 import 'package:app/core/view_models/active_screen_view_model.dart';
+import 'package:app/ui/views/active/form_field/acknowledgement_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/delivery_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/loading_vehicle_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/shipper_info_form_field.dart';
@@ -40,6 +42,7 @@ class _ATREditingScreenState extends State<ATREditingScreen> {
   FeedWaterRestInfoFormField _feedWaterRestInfoFormField;
   LoadingVehicleInfoFormField _loadingVehicleInfoFormField;
   DeliveryInfoFormField _deliveryInfoFormField;
+  AcknowledgementInfoFormField _acknowledgementInfoFormField;
 
   @override
   void initState() {
@@ -67,6 +70,11 @@ class _ATREditingScreenState extends State<ATREditingScreen> {
       onSaved: (DeliveryInfo newInfo) =>
           _replacementAtr = _replacementAtr.withDeliveryInfo(newInfo),
     );
+    _acknowledgementInfoFormField = AcknowledgementInfoFormField(
+      initialInfo: _replacementAtr.ackInfo,
+      onSaved: (AcknowledgementInfo newInfo) =>
+          _replacementAtr = _replacementAtr.withAckInfo(newInfo),
+    );
 
     _atrFormFieldsWrapper.addAll([
       ExpansionListItem(
@@ -83,7 +91,10 @@ class _ATREditingScreenState extends State<ATREditingScreen> {
           headerValue: _loadingVehicleInfoFormField.title),
       ExpansionListItem(
           expandedValue: _deliveryInfoFormField,
-          headerValue: _deliveryInfoFormField.title)
+          headerValue: _deliveryInfoFormField.title),
+      ExpansionListItem(
+          expandedValue: _acknowledgementInfoFormField,
+          headerValue: _acknowledgementInfoFormField.title)
     ]);
   }
 

--- a/app/lib/ui/views/active/atr_editing_screen.dart
+++ b/app/lib/ui/views/active/atr_editing_screen.dart
@@ -1,5 +1,6 @@
 import 'package:app/core/models/acknowledgement_info.dart';
 import 'package:app/core/models/animal_transport_record.dart';
+import 'package:app/core/models/contingency_plan_info.dart';
 import 'package:app/core/models/delivery_info.dart';
 import 'package:app/core/models/feed_water_rest_info.dart';
 import 'package:app/core/models/loading_vehicle_info.dart';
@@ -10,6 +11,7 @@ import 'package:app/core/services/navigation/nav_service.dart';
 import 'package:app/core/services/service_locator.dart';
 import 'package:app/core/view_models/active_screen_view_model.dart';
 import 'package:app/ui/views/active/form_field/acknowledgement_info_form_field.dart';
+import 'package:app/ui/views/active/form_field/contingency_plan_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/delivery_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/loading_vehicle_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/shipper_info_form_field.dart';
@@ -43,6 +45,7 @@ class _ATREditingScreenState extends State<ATREditingScreen> {
   LoadingVehicleInfoFormField _loadingVehicleInfoFormField;
   DeliveryInfoFormField _deliveryInfoFormField;
   AcknowledgementInfoFormField _acknowledgementInfoFormField;
+  ContingencyPlanInfoFormField _contingencyPlanInfoFormField;
 
   @override
   void initState() {
@@ -75,6 +78,11 @@ class _ATREditingScreenState extends State<ATREditingScreen> {
       onSaved: (AcknowledgementInfo newInfo) =>
           _replacementAtr = _replacementAtr.withAckInfo(newInfo),
     );
+    _contingencyPlanInfoFormField = ContingencyPlanInfoFormField(
+      initialInfo: _replacementAtr.contingencyInfo,
+      onSaved: (ContingencyPlanInfo newInfo) =>
+          _replacementAtr = _replacementAtr.withContingencyInfo(newInfo),
+    );
 
     _atrFormFieldsWrapper.addAll([
       ExpansionListItem(
@@ -94,12 +102,15 @@ class _ATREditingScreenState extends State<ATREditingScreen> {
           headerValue: _deliveryInfoFormField.title),
       ExpansionListItem(
           expandedValue: _acknowledgementInfoFormField,
-          headerValue: _acknowledgementInfoFormField.title)
+          headerValue: _acknowledgementInfoFormField.title),
+      ExpansionListItem(
+          expandedValue: _contingencyPlanInfoFormField,
+          headerValue: _contingencyPlanInfoFormField.title)
     ]);
   }
 
   void _submitATR() {
-    // TODO: Call service and submit the completed atr
+    // TODO: #178. Call service and submit the completed atr
     widget._dialogService
         .showDialog(
             title: "Animal Transport Form Submitted",

--- a/app/lib/ui/views/active/dynamic_form_field/dynamic_contingency_activity_form_field.dart
+++ b/app/lib/ui/views/active/dynamic_form_field/dynamic_contingency_activity_form_field.dart
@@ -1,0 +1,33 @@
+import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/ui/views/active/form_field/contingency_activity_form_field.dart';
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
+import 'dynamic_form_field.dart';
+
+/// A custom form field for ContingencyActivities.
+/// Due to it's dynamic nature this widget should only be used inside a grow-able
+/// widget, like column, and not inside static widgets like ListTiles.
+dynamicContingencyActivityFormField(
+        {@required List<ContingencyActivity> initialList,
+        @required Function(List<ContingencyActivity>) onSaved}) =>
+    DynamicFormField<ContingencyActivity, ContingencyActivityFormField>(
+        initialList: initialList,
+        titles: "Carrier's communication activities",
+        onSaved: onSaved,
+        blankFieldCreator: () => ContingencyActivity(
+            time: TimeOfDay.now(),
+            personContacted: "",
+            methodOfContact: "",
+            instructionsGiven: ""),
+        fieldCreator: (int index,
+                ContingencyActivity it,
+                Function(int, ContingencyActivity) onSaved,
+                Function(int) onDelete) =>
+            ContingencyActivityFormField(
+                // Must have unique keys in rebuilding widget lists
+                key: ObjectKey(Uuid().v4()),
+                initial: it,
+                onSaved: (ContingencyActivity changed) =>
+                    onSaved(index, changed),
+                onDelete: () => onDelete(index)));

--- a/app/lib/ui/views/active/dynamic_form_field/dynamic_contingency_plan_event_form_field.dart
+++ b/app/lib/ui/views/active/dynamic_form_field/dynamic_contingency_plan_event_form_field.dart
@@ -1,0 +1,35 @@
+import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/ui/views/active/form_field/contingency_plan_event_form_field.dart';
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
+import 'dynamic_form_field.dart';
+
+/// A custom form field for ContingencyPlanEvents.
+/// Due to it's dynamic nature this widget should only be used inside a grow-able
+/// widget, like column, and not inside static widgets like ListTiles.
+dynamicContingencyPlanEventFormField(
+        {@required List<ContingencyPlanEvent> initialList,
+        @required Function(List<ContingencyPlanEvent>) onSaved}) =>
+    DynamicFormField<ContingencyPlanEvent, ContingencyPlanEventFormField>(
+        initialList: initialList,
+        titles: "Event Specific Plans",
+        onSaved: onSaved,
+        blankFieldCreator: () => ContingencyPlanEvent(
+            eventDateAndTime: DateTime.now(),
+            producerContactsUsed: [],
+            receiverContactsUsed: [],
+            disturbancesIdentified: "",
+            activities: [],
+            actionsTaken: []),
+        fieldCreator: (int index,
+                ContingencyPlanEvent it,
+                Function(int, ContingencyPlanEvent) onSaved,
+                Function(int) onDelete) =>
+            ContingencyPlanEventFormField(
+                // Must have unique keys in rebuilding widget lists
+                key: ObjectKey(Uuid().v4()),
+                initial: it,
+                onSaved: (ContingencyPlanEvent changed) =>
+                    onSaved(index, changed),
+                onDelete: () => onDelete(index)));

--- a/app/lib/ui/views/active/form_field/acknowledgement_info_form_field.dart
+++ b/app/lib/ui/views/active/form_field/acknowledgement_info_form_field.dart
@@ -1,0 +1,49 @@
+import 'package:app/core/models/acknowledgement_info.dart';
+import 'package:flutter/material.dart';
+
+class AcknowledgementInfoFormField extends StatefulWidget {
+  final Function(AcknowledgementInfo info) onSaved;
+  final AcknowledgementInfo initialInfo;
+  final String title = "Acknowledgements";
+
+  // Use the form key to save all the fields of this form
+  final formKey = GlobalKey<FormState>();
+
+  AcknowledgementInfoFormField(
+      {Key key, @required this.initialInfo, @required this.onSaved})
+      : super(key: key);
+
+  @override
+  _AcknowledgementInfoFormFieldState createState() =>
+      _AcknowledgementInfoFormFieldState();
+}
+
+class _AcknowledgementInfoFormFieldState
+    extends State<AcknowledgementInfoFormField> {
+// TODO: Resolve how to edit ack info
+  void _saveAll() {
+    widget.onSaved(widget.initialInfo);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: widget.formKey,
+      child: Column(children: [
+        ListTile(
+          title: Text("Shipper acknowledgement"),
+          subtitle: Text("TODO"),
+        ),
+        ListTile(
+          title: Text("Transporter acknowledgement"),
+          subtitle: Text("TODO"),
+        ),
+        ListTile(
+          title: Text("Consignee acknowledgement"),
+          subtitle: Text("TODO"),
+        ),
+        RaisedButton(child: Text("Save"), onPressed: _saveAll)
+      ]),
+    );
+  }
+}

--- a/app/lib/ui/views/active/form_field/compromised_animal_form_field.dart
+++ b/app/lib/ui/views/active/form_field/compromised_animal_form_field.dart
@@ -45,6 +45,10 @@ class _CompromisedAnimalFormFieldState
       children: [
         ListTile(
           title: Text(widget.title),
+          trailing: IconButton(
+            icon: Icon(Icons.delete),
+            onPressed: widget.onDelete,
+          ),
         ),
         StringFormField(
           initial: _animalDescription,
@@ -53,7 +57,7 @@ class _CompromisedAnimalFormFieldState
             _animalDescription = changed;
             _saveAll();
           },
-          onDelete: Optional.of(widget.onDelete),
+          onDelete: Optional.empty(),
           isMultiline: true,
         ),
         StringFormField(

--- a/app/lib/ui/views/active/form_field/contingency_activity_form_field.dart
+++ b/app/lib/ui/views/active/form_field/contingency_activity_form_field.dart
@@ -1,0 +1,97 @@
+import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/core/utilities/optional.dart';
+import 'package:app/ui/views/active/form_field/string_form_field.dart';
+import 'package:app/ui/widgets/utility/date_time_picker.dart';
+import 'package:flutter/material.dart';
+
+/// A custom form field with onSaved and onDelete callback
+class ContingencyActivityFormField extends StatefulWidget {
+  final ContingencyActivity initial;
+  final Function(ContingencyActivity) onSaved;
+  final Function() onDelete;
+
+  ContingencyActivityFormField(
+      {Key key,
+      @required this.initial,
+      @required this.onSaved,
+      @required this.onDelete})
+      : super(key: key);
+
+  @override
+  _ContingencyActivityFormFieldState createState() =>
+      _ContingencyActivityFormFieldState();
+}
+
+class _ContingencyActivityFormFieldState
+    extends State<ContingencyActivityFormField> {
+  TimeOfDay _time;
+  String _personContacted;
+  String _methodOfContact;
+  String _instructionsGiven;
+
+  @override
+  void initState() {
+    _time = widget.initial.time;
+    _personContacted = widget.initial.personContacted;
+    _methodOfContact = widget.initial.methodOfContact;
+    _instructionsGiven = widget.initial.instructionsGiven;
+    super.initState();
+  }
+
+  void _saveAll() => widget.onSaved(ContingencyActivity(
+      time: _time,
+      personContacted: _personContacted,
+      methodOfContact: _methodOfContact,
+      instructionsGiven: _instructionsGiven));
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ListTile(
+          title: Text("Carrier's communication activity"),
+          trailing: IconButton(
+            icon: Icon(Icons.delete),
+            onPressed: widget.onDelete,
+          ),
+        ),
+        ListTile(
+          title: Text("Time of communication"),
+          subtitle: timePicker(
+              initialTime: _time,
+              onSaved: (String changed) {
+                _time = TimeOfDay.fromDateTime(DateTime.parse(changed));
+                _saveAll();
+              }),
+        ),
+        StringFormField(
+          initial: _personContacted,
+          title: "Who was contacted",
+          onSaved: (String changed) {
+            _personContacted = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty(),
+        ),
+        StringFormField(
+            initial: _methodOfContact,
+            title: "Communication method used",
+            onSaved: (String changed) {
+              _methodOfContact = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        StringFormField(
+            initial: _instructionsGiven,
+            isMultiline: true,
+            title:
+                "What instructions were given and decisions made with the guidance of emergency contacts reached",
+            onSaved: (String changed) {
+              _instructionsGiven = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty())
+      ],
+    );
+  }
+}

--- a/app/lib/ui/views/active/form_field/contingency_plan_event_form_field.dart
+++ b/app/lib/ui/views/active/form_field/contingency_plan_event_form_field.dart
@@ -1,0 +1,140 @@
+import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/core/utilities/optional.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_contingency_activity_form_field.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_string_form_field.dart';
+import 'package:app/ui/views/active/form_field/contingency_activity_form_field.dart';
+import 'package:app/ui/views/active/form_field/string_form_field.dart';
+import 'package:app/ui/widgets/utility/date_time_picker.dart';
+import 'package:flutter/material.dart';
+
+/// A custom form field with onSaved and onDelete callback
+class ContingencyPlanEventFormField extends StatefulWidget {
+  final ContingencyPlanEvent initial;
+  final Function(ContingencyPlanEvent) onSaved;
+  final Function() onDelete;
+
+  ContingencyPlanEventFormField(
+      {Key key,
+      @required this.initial,
+      @required this.onSaved,
+      @required this.onDelete})
+      : super(key: key);
+
+  @override
+  _ContingencyPlanEventFormFieldState createState() =>
+      _ContingencyPlanEventFormFieldState();
+}
+
+class _ContingencyPlanEventFormFieldState
+    extends State<ContingencyPlanEventFormField> {
+  DateTime _eventDateAndTime;
+  List<String> _producerContactsUsed;
+  List<String> _receiverContactsUsed;
+  String _disturbancesIdentified;
+  List<ContingencyActivity> _activities;
+  List<String> _actionsTaken;
+
+  DynamicFormField<String, StringFormField> _producerContactsUsedFormField;
+  DynamicFormField<String, StringFormField> _receiverContactsUsedFormField;
+  DynamicFormField<String, StringFormField> _actionsTakenFormField;
+  DynamicFormField<ContingencyActivity, ContingencyActivityFormField>
+      _contingencyActivitiesFormField;
+
+  @override
+  void initState() {
+    _eventDateAndTime = widget.initial.eventDateAndTime;
+    _producerContactsUsed = widget.initial.producerContactsUsed;
+    _receiverContactsUsed = widget.initial.receiverContactsUsed;
+    _disturbancesIdentified = widget.initial.disturbancesIdentified;
+    _activities = widget.initial.activities;
+    _actionsTaken = widget.initial.actionsTaken;
+
+    _producerContactsUsedFormField = dynamicStringFormField(
+        initialList: _producerContactsUsed,
+        onSaved: (List<String> changed) {
+          _producerContactsUsed = changed;
+          _saveAll();
+        },
+        titles: "Producer contact used");
+    _receiverContactsUsedFormField = dynamicStringFormField(
+        initialList: _receiverContactsUsed,
+        onSaved: (List<String> changed) {
+          _receiverContactsUsed = changed;
+          _saveAll();
+        },
+        titles: "Receiver contact used");
+    _actionsTakenFormField = dynamicStringFormField(
+        initialList: _actionsTaken,
+        onSaved: (List<String> changed) {
+          _actionsTaken = changed;
+          _saveAll();
+        },
+        titles: "Action taken");
+    _contingencyActivitiesFormField = dynamicContingencyActivityFormField(
+        initialList: _activities,
+        onSaved: (List<ContingencyActivity> changed) {
+          _activities = changed;
+          _saveAll();
+        });
+    super.initState();
+  }
+
+  void _saveAll() => widget.onSaved(ContingencyPlanEvent(
+      eventDateAndTime: _eventDateAndTime,
+      producerContactsUsed: _producerContactsUsed,
+      receiverContactsUsed: _receiverContactsUsed,
+      disturbancesIdentified: _disturbancesIdentified,
+      activities: _activities,
+      actionsTaken: _actionsTaken));
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ListTile(
+          title: Text("Event Specific Plan"),
+          trailing: IconButton(
+            icon: Icon(Icons.delete),
+            onPressed: widget.onDelete,
+          ),
+        ),
+        ListTile(
+          title: Text("Date and time of event"),
+          subtitle: dateTimePicker(
+              initialDate: _eventDateAndTime,
+              onSaved: (String changed) {
+                _eventDateAndTime = DateTime.parse(changed);
+                _saveAll();
+              }),
+        ),
+        ListTile(
+          title: Text("Producer's emergency contacts used"),
+        ),
+        _producerContactsUsedFormField,
+        ListTile(
+          title: Text("Receiver's emergency contacts used"),
+        ),
+        _receiverContactsUsedFormField,
+        StringFormField(
+            initial: _disturbancesIdentified,
+            isMultiline: true,
+            title: "Disturbances identified",
+            onSaved: (String changed) {
+              _disturbancesIdentified = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        ListTile(
+          title: Text(
+              "List of animal welfare related measures and actions taken(specific to the event)"),
+        ),
+        _actionsTakenFormField,
+        ListTile(
+          title: Text("Carrier's communication activities"),
+        ),
+        _contingencyActivitiesFormField,
+      ],
+    );
+  }
+}

--- a/app/lib/ui/views/active/form_field/contingency_plan_info_form_field.dart
+++ b/app/lib/ui/views/active/form_field/contingency_plan_info_form_field.dart
@@ -1,0 +1,160 @@
+import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/core/utilities/optional.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_contingency_plan_event_form_field.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_string_form_field.dart';
+import 'package:app/ui/views/active/form_field/contingency_plan_event_form_field.dart';
+import 'package:app/ui/views/active/form_field/string_form_field.dart';
+import 'package:flutter/material.dart';
+
+class ContingencyPlanInfoFormField extends StatefulWidget {
+  final Function(ContingencyPlanInfo info) onSaved;
+  final ContingencyPlanInfo initialInfo;
+  final String title = "Contingency Plan";
+
+  // Use the form key to save all the fields of this form
+  final formKey = GlobalKey<FormState>();
+
+  ContingencyPlanInfoFormField(
+      {Key key, @required this.initialInfo, @required this.onSaved})
+      : super(key: key);
+
+  @override
+  _ContingencyPlanInfoFormFieldState createState() =>
+      _ContingencyPlanInfoFormFieldState();
+}
+
+class _ContingencyPlanInfoFormFieldState
+    extends State<ContingencyPlanInfoFormField> {
+  String _goalStatement;
+  String _communicationPlan;
+  List<String> _crisisContacts;
+  String _expectedPrepProcess;
+  String _standardAnimalMonitoring;
+  List<String> _potentialHazards;
+  List<String> _potentialSafetyActions;
+  List<ContingencyPlanEvent> _contingencyEvents;
+
+  DynamicFormField<String, StringFormField> _crisisContactsFormField;
+  DynamicFormField<String, StringFormField> _potentialHazardsFormField;
+  DynamicFormField<String, StringFormField> _potentialSafetyActionsFormField;
+  DynamicFormField<ContingencyPlanEvent, ContingencyPlanEventFormField>
+      _contingencyEventsFormField;
+
+  @override
+  void initState() {
+    _goalStatement = widget.initialInfo.goalStatement;
+    _communicationPlan = widget.initialInfo.communicationPlan;
+    _crisisContacts = widget.initialInfo.crisisContacts;
+    _expectedPrepProcess = widget.initialInfo.expectedPrepProcess;
+    _standardAnimalMonitoring = widget.initialInfo.standardAnimalMonitoring;
+    _potentialHazards = widget.initialInfo.potentialHazards;
+    _potentialSafetyActions = widget.initialInfo.potentialSafetyActions;
+    _contingencyEvents = widget.initialInfo.contingencyEvents;
+
+    _crisisContactsFormField = dynamicStringFormField(
+        initialList: _crisisContacts,
+        onSaved: (List<String> changed) {
+          _crisisContacts = changed;
+          _saveAll();
+        },
+        titles: "Producer contact used");
+    _potentialHazardsFormField = dynamicStringFormField(
+        initialList: _potentialHazards,
+        onSaved: (List<String> changed) {
+          _potentialHazards = changed;
+          _saveAll();
+        },
+        titles: "Receiver contact used");
+    _potentialSafetyActionsFormField = dynamicStringFormField(
+        initialList: _potentialSafetyActions,
+        onSaved: (List<String> changed) {
+          _potentialSafetyActions = changed;
+          _saveAll();
+        },
+        titles: "Action taken");
+    _contingencyEventsFormField = dynamicContingencyPlanEventFormField(
+        initialList: _contingencyEvents,
+        onSaved: (List<ContingencyPlanEvent> changed) {
+          _contingencyEvents = changed;
+          _saveAll();
+        });
+    super.initState();
+  }
+
+  void _saveAll() => widget.onSaved(ContingencyPlanInfo(
+      goalStatement: _goalStatement,
+      communicationPlan: _communicationPlan,
+      crisisContacts: _crisisContacts,
+      expectedPrepProcess: _expectedPrepProcess,
+      standardAnimalMonitoring: _standardAnimalMonitoring,
+      potentialHazards: _potentialHazards,
+      potentialSafetyActions: _potentialSafetyActions,
+      contingencyEvents: _contingencyEvents));
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: widget.formKey,
+      child: Column(children: [
+        StringFormField(
+            initial: _goalStatement,
+            isMultiline: true,
+            title:
+                "Goal Statement (company’s goal and purpose of the plan i.e avoid animal suffering)",
+            onSaved: (String changed) {
+              _goalStatement = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        StringFormField(
+            initial: _communicationPlan,
+            isMultiline: true,
+            title:
+                "Communication Plan (who should be contacted and who will initiate or permit the process?)",
+            onSaved: (String changed) {
+              _communicationPlan = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        ListTile(
+          title: Text(
+              "Crisis contacts and links (general helpline, industry related links and websites)"),
+        ),
+        _crisisContactsFormField,
+        StringFormField(
+            initial: _expectedPrepProcess,
+            isMultiline: true,
+            title:
+                "Expected Preparation Process (what should be done prior to loading animals?)",
+            onSaved: (String changed) {
+              _expectedPrepProcess = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        StringFormField(
+            initial: _standardAnimalMonitoring,
+            isMultiline: true,
+            title: "Standard Animal Monitoring",
+            onSaved: (String changed) {
+              _standardAnimalMonitoring = changed;
+              _saveAll();
+            },
+            onDelete: Optional.empty()),
+        ListTile(
+          title: Text("Potential Hazard/Events/Challenges"),
+        ),
+        _potentialHazardsFormField,
+        ListTile(
+          title: Text("Potential Actions to Ensure Human or Animal Safety"),
+        ),
+        _potentialSafetyActionsFormField,
+        ListTile(
+          title: Text("Event Specific Plan(s)"),
+        ),
+        _contingencyEventsFormField,
+        RaisedButton(child: Text("Save"), onPressed: _saveAll)
+      ]),
+    );
+  }
+}

--- a/app/lib/ui/widgets/utility/date_time_picker.dart
+++ b/app/lib/ui/widgets/utility/date_time_picker.dart
@@ -11,3 +11,18 @@ DateTimePicker dateTimePicker(
       onSaved: onSaved,
       onChanged: onSaved,
     );
+
+DateTimePicker timePicker(
+        {@required TimeOfDay initialTime,
+        @required Function(String) onSaved}) =>
+    DateTimePicker(
+      type: DateTimePickerType.time,
+      initialValue: convertTimeOfDayToString(initialTime),
+      onSaved: onSaved,
+      onChanged: onSaved,
+    );
+
+/// The TimeOfDay toString() is not like DateTime toString()
+/// This function converts it to the expected string of HH:mm
+String convertTimeOfDayToString(TimeOfDay initialTime) =>
+    initialTime.toString().substring(10, 15);

--- a/app/test/ui/views/active/atr_editing_screen_test.dart
+++ b/app/test/ui/views/active/atr_editing_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:app/core/services/navigation/nav_service.dart';
 import 'package:app/core/view_models/active_screen_view_model.dart';
 import 'package:app/test/test_animal_transport_record.dart';
 import 'package:app/ui/views/active/atr_editing_screen.dart';
+import 'package:app/ui/views/active/form_field/acknowledgement_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/delivery_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/fwr_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/loading_vehicle_info_form_field.dart';
@@ -65,6 +66,12 @@ void main() {
     testWidgets('has delivery info form field', (WidgetTester tester) async {
       await pumpATREditingScreen(tester, testAnimalTransportRecord());
       expect(find.byType(DeliveryInfoFormField), findsOneWidget);
+    });
+
+    testWidgets('has acknowledgement info form field',
+        (WidgetTester tester) async {
+      await pumpATREditingScreen(tester, testAnimalTransportRecord());
+      expect(find.byType(AcknowledgementInfoFormField), findsOneWidget);
     });
 
     testWidgets('shows submit button', (WidgetTester tester) async {

--- a/app/test/ui/views/active/atr_editing_screen_test.dart
+++ b/app/test/ui/views/active/atr_editing_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:app/core/view_models/active_screen_view_model.dart';
 import 'package:app/test/test_animal_transport_record.dart';
 import 'package:app/ui/views/active/atr_editing_screen.dart';
 import 'package:app/ui/views/active/form_field/acknowledgement_info_form_field.dart';
+import 'package:app/ui/views/active/form_field/contingency_plan_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/delivery_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/fwr_info_form_field.dart';
 import 'package:app/ui/views/active/form_field/loading_vehicle_info_form_field.dart';
@@ -72,6 +73,12 @@ void main() {
         (WidgetTester tester) async {
       await pumpATREditingScreen(tester, testAnimalTransportRecord());
       expect(find.byType(AcknowledgementInfoFormField), findsOneWidget);
+    });
+
+    testWidgets('has contingency plan info form field',
+        (WidgetTester tester) async {
+      await pumpATREditingScreen(tester, testAnimalTransportRecord());
+      expect(find.byType(ContingencyPlanInfoFormField), findsOneWidget);
     });
 
     testWidgets('shows submit button', (WidgetTester tester) async {

--- a/app/test/ui/views/active/form_field/acknowledgement_info_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/acknowledgement_info_form_field_test.dart
@@ -1,0 +1,49 @@
+import 'package:app/core/models/acknowledgement_info.dart';
+import 'package:app/test/test_animal_transport_record.dart';
+import 'package:app/ui/views/active/form_field/acknowledgement_info_form_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpAckInfoFormField(
+          WidgetTester tester,
+          AcknowledgementInfo testInfo,
+          Function(AcknowledgementInfo) callback) async =>
+      tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+              body: SingleChildScrollView(
+                  child: Container(
+        child: AcknowledgementInfoFormField(
+            initialInfo: testInfo, onSaved: callback),
+      )))));
+
+  group('Acknowledgement Info Form Field', () {
+    testWidgets('shows right information', (WidgetTester tester) async {});
+
+    testWidgets('shows save button', (WidgetTester tester) async {
+      final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
+      await pumpAckInfoFormField(tester, testAckInfo(), (_) {
+        // Do nothing for test
+      });
+      await tester.ensureVisible(saveButtonFinder);
+      expect(saveButtonFinder, findsOneWidget);
+    });
+
+    testWidgets('calls onSaved when save button pressed',
+        (WidgetTester tester) async {
+      final testInfo = testAckInfo();
+      final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
+      AcknowledgementInfo callbackInfo;
+      final onSavedCallback = (AcknowledgementInfo info) => callbackInfo = info;
+
+      await pumpAckInfoFormField(tester, testInfo, onSavedCallback);
+      await tester.ensureVisible(saveButtonFinder);
+      await tester.tap(saveButtonFinder);
+      await tester.pumpAndSettle();
+      expect(callbackInfo, testInfo);
+    });
+
+    testWidgets('calls onSaved when acknowledgement edited',
+        (WidgetTester tester) async {});
+  });
+}

--- a/app/test/ui/views/active/form_field/contingency_activity_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/contingency_activity_form_field_test.dart
@@ -1,0 +1,78 @@
+import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/test/helper/test_contingency_activity_expectations.dart';
+import 'package:app/test/test_animal_transport_record.dart';
+import 'package:app/ui/views/active/form_field/contingency_activity_form_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpContingencyActivityFormField(
+          WidgetTester tester,
+          ContingencyActivity initial,
+          Function(ContingencyActivity) onSaved,
+          Function() onDelete) async =>
+      tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+              body: ContingencyActivityFormField(
+        initial: initial,
+        onSaved: onSaved,
+        onDelete: onDelete,
+      ))));
+
+  group('Contingency Activity Form Field', () {
+    testWidgets('shows right information', (WidgetTester tester) async {
+      final contingencyActivity = ContingencyActivity(
+          time: TimeOfDay.fromDateTime(DateTime.parse("0000-01-01 19:22")),
+          personContacted: "Jamie Hill",
+          methodOfContact: "Phone call",
+          instructionsGiven: "Wait for authorities to arrive");
+      await pumpContingencyActivityFormField(tester, contingencyActivity, (_) {
+        // do nothing for test
+      }, () {
+        // do nothing for test
+      });
+      verifyContingencyActivityShown(contingencyActivity);
+    });
+
+    testWidgets('calls onDelete when delete button pressed',
+        (WidgetTester tester) async {
+      bool callback;
+      final onDeleteCallback = () => callback = true;
+      final deleteButtonFinder = find.byIcon(Icons.delete);
+      await pumpContingencyActivityFormField(tester, testContingencyActivity(),
+          (_) {
+        // do nothing for test
+      }, onDeleteCallback);
+      await tester.ensureVisible(deleteButtonFinder);
+      await tester.tap(deleteButtonFinder);
+      await tester.pumpAndSettle();
+      expect(callback, isTrue);
+    });
+
+    testWidgets('onSaved called when edited', (WidgetTester tester) async {
+      final testContact = "Jamie Foxx";
+      final editedContact = "Meghan Foxx";
+      ContingencyActivity callback;
+      final onSavedCallback =
+          (ContingencyActivity changed) => callback = changed;
+      final fieldFinder = find.widgetWithText(TextFormField, testContact);
+      final editedFieldFinder =
+          find.widgetWithText(TextFormField, editedContact);
+      final testActivity =
+          testContingencyActivity(personContacted: testContact);
+      final editedActivity =
+          testContingencyActivity(personContacted: editedContact);
+
+      await pumpContingencyActivityFormField(
+          tester, testActivity, onSavedCallback, () {
+        // do nothing for test
+      });
+      await tester.enterText(fieldFinder, editedContact);
+      await tester.pumpAndSettle();
+      // expect was saved
+      expect(callback, editedActivity);
+      // expect edited text visible
+      expect(editedFieldFinder, findsOneWidget);
+    });
+  });
+}

--- a/app/test/ui/views/active/form_field/contingency_plan_event_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/contingency_plan_event_form_field_test.dart
@@ -1,0 +1,84 @@
+import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/test/helper/test_contingency_plan_event_expectations.dart';
+import 'package:app/test/test_animal_transport_record.dart';
+import 'package:app/ui/views/active/form_field/contingency_plan_event_form_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpContingencyPlanEventFormField(
+          WidgetTester tester,
+          ContingencyPlanEvent initial,
+          Function(ContingencyPlanEvent) onSaved,
+          Function() onDelete) async =>
+      tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+              body: SingleChildScrollView(
+        child: ContingencyPlanEventFormField(
+          initial: initial,
+          onSaved: onSaved,
+          onDelete: onDelete,
+        ),
+      ))));
+
+  group('Contingency Plan Event Form Field', () {
+    testWidgets('shows right information', (WidgetTester tester) async {
+      final contingencyEvent = ContingencyPlanEvent(
+          eventDateAndTime: DateTime.parse("2020-01-01 19:32"),
+          producerContactsUsed: ["Phone"],
+          receiverContactsUsed: ["Text"],
+          disturbancesIdentified: "Cow was bleeding heavily",
+          activities: [testContingencyActivity()],
+          actionsTaken: ["Bandaged up cow"]);
+      await pumpContingencyPlanEventFormField(tester, contingencyEvent, (_) {
+        // do nothing for test
+      }, () {
+        // do nothing for test
+      });
+      verifyContingencyPlanEventShown(contingencyEvent);
+    });
+
+    testWidgets('calls onDelete when delete button pressed',
+        (WidgetTester tester) async {
+      bool callback;
+      final onDeleteCallback = () => callback = true;
+      final deleteButtonFinder = find.byIcon(Icons.delete).first;
+      await pumpContingencyPlanEventFormField(tester, testContingencyEvent(),
+          (_) {
+        // do nothing for test
+      }, onDeleteCallback);
+      await tester.ensureVisible(deleteButtonFinder);
+      await tester.tap(deleteButtonFinder);
+      await tester.pumpAndSettle();
+      expect(callback, isTrue);
+    });
+
+    testWidgets('onSaved called when contingency activity edited',
+        (WidgetTester tester) async {
+      final testContact = "Jamie Foxx";
+      final editedContact = "Meghan Foxx";
+      ContingencyPlanEvent callback;
+      final onSavedCallback =
+          (ContingencyPlanEvent changed) => callback = changed;
+      final fieldFinder = find.widgetWithText(TextFormField, testContact);
+      final editedFieldFinder =
+          find.widgetWithText(TextFormField, editedContact);
+      final testEvent = testContingencyEvent(
+          activities: [testContingencyActivity(personContacted: testContact)]);
+      final editedEvent = testContingencyEvent(activities: [
+        testContingencyActivity(personContacted: editedContact)
+      ]);
+
+      await pumpContingencyPlanEventFormField(
+          tester, testEvent, onSavedCallback, () {
+        // do nothing for test
+      });
+      await tester.enterText(fieldFinder, editedContact);
+      await tester.pumpAndSettle();
+      // expect was saved
+      expect(callback, editedEvent);
+      // expect edited text visible
+      expect(editedFieldFinder, findsOneWidget);
+    });
+  });
+}

--- a/app/test/ui/views/active/form_field/contingency_plan_info_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/contingency_plan_info_form_field_test.dart
@@ -1,0 +1,111 @@
+import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/test/helper/test_contingency_plan_event_expectations.dart';
+import 'package:app/test/test_animal_transport_record.dart';
+import 'package:app/ui/views/active/form_field/contingency_plan_info_form_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  void verifyInformationIsShown(ContingencyPlanInfo infoExpected) {
+    expect(find.text(infoExpected.goalStatement), findsOneWidget);
+    expect(find.text(infoExpected.communicationPlan), findsOneWidget);
+    expect(find.text(infoExpected.expectedPrepProcess), findsOneWidget);
+    expect(find.text(infoExpected.standardAnimalMonitoring), findsOneWidget);
+    infoExpected.crisisContacts.forEach((contact) {
+      expect(find.text(contact), findsOneWidget);
+    });
+    infoExpected.potentialHazards.forEach((hazard) {
+      expect(find.text(hazard), findsOneWidget);
+    });
+    infoExpected.potentialSafetyActions.forEach((action) {
+      expect(find.text(action), findsOneWidget);
+    });
+    infoExpected.contingencyEvents.forEach((event) {
+      verifyContingencyPlanEventShown(event);
+    });
+  }
+
+  Future<void> pumpContingencyPlanInfoFormField(
+          WidgetTester tester,
+          ContingencyPlanInfo testInfo,
+          Function(ContingencyPlanInfo) callback) async =>
+      tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+              body: SingleChildScrollView(
+                  child: Container(
+        child: ContingencyPlanInfoFormField(
+            initialInfo: testInfo, onSaved: callback),
+      )))));
+
+  group('Contingency Plan Info Form Field', () {
+    testWidgets('shows right information', (WidgetTester tester) async {
+      final contingencyPlanInfo = ContingencyPlanInfo(
+          goalStatement: "To protect the world from devastation",
+          communicationPlan: "To unite all evil within our nation",
+          crisisContacts: ["Jessie", "James"],
+          expectedPrepProcess: "To denounce the evils of truth and love",
+          standardAnimalMonitoring: "To extend our reach to the stars above",
+          potentialHazards: ["Meowth", "That's right!"],
+          potentialSafetyActions: [
+            "Team Rocket blasting off at the speed of light!"
+          ],
+          contingencyEvents: []);
+      await pumpContingencyPlanInfoFormField(tester, contingencyPlanInfo, (_) {
+        // Do nothing for test
+      });
+      verifyInformationIsShown(contingencyPlanInfo);
+    });
+
+    testWidgets('shows save button', (WidgetTester tester) async {
+      final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
+      await pumpContingencyPlanInfoFormField(tester, testContingencyInfo(),
+          (_) {
+        // Do nothing for test
+      });
+      await tester.ensureVisible(saveButtonFinder);
+      expect(saveButtonFinder, findsOneWidget);
+    });
+
+    testWidgets('calls onSaved when save button pressed',
+        (WidgetTester tester) async {
+      final testInfo = testContingencyInfo();
+      final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
+      ContingencyPlanInfo callbackInfo;
+      final onSavedCallback = (ContingencyPlanInfo info) => callbackInfo = info;
+
+      await pumpContingencyPlanInfoFormField(tester, testInfo, onSavedCallback);
+      await tester.ensureVisible(saveButtonFinder);
+      await tester.tap(saveButtonFinder);
+      await tester.pumpAndSettle();
+      expect(callbackInfo, testInfo);
+    });
+
+    testWidgets(
+        'calls onSaved with edited contingency event when save button pressed',
+        (WidgetTester tester) async {
+      final testContact = "Jamie Foxx";
+      final editedContact = "Meghan Foxx";
+      ContingencyPlanInfo callback;
+      final onSaved = (ContingencyPlanInfo changed) => callback = changed;
+      final fieldFinder = find.widgetWithText(TextFormField, testContact);
+      final testInfo = testContingencyInfo(contingencyEvents: [
+        testContingencyEvent(receiverContactsUsed: [testContact])
+      ]);
+      final editedInfo = testContingencyInfo(contingencyEvents: [
+        testContingencyEvent(receiverContactsUsed: [editedContact])
+      ]);
+      final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
+
+      await pumpContingencyPlanInfoFormField(tester, testInfo, onSaved);
+      // Edit text
+      await tester.ensureVisible(fieldFinder);
+      await tester.enterText(fieldFinder, editedContact);
+      await tester.pumpAndSettle();
+      // Save
+      await tester.ensureVisible(saveButtonFinder);
+      await tester.tap(saveButtonFinder);
+      await tester.pumpAndSettle();
+      expect(callback, editedInfo);
+    });
+  });
+}


### PR DESCRIPTION
Closes #134 !!!!!

In this PR I have added:
1. The placeholder for ack info in the editing screen. That's probably where we'll launch image picker overlay
2. `ContingencyPlanInfoFormField` and it's sub forms

***

Looks like:



https://user-images.githubusercontent.com/32527219/109409783-15396580-795b-11eb-86d2-6c554f25aaf8.mp4

