### PR TITLE
Revise AuthenticationService in how it gets the current user. Change FirestoreUser to Transporter

### DIFF
--- a/app/lib/core/models/transporter.dart
+++ b/app/lib/core/models/transporter.dart
@@ -1,12 +1,14 @@
-class FirestoreUser {
+class Transporter {
   final String firstName;
   final String lastName;
   final String userEmailAddress;
   final String userPhoneNumber;
+
+  // The user ID should be the same as the current User of the app
   final String userId;
   final bool isAdmin;
 
-  FirestoreUser(
+  Transporter(
       {this.firstName,
       this.lastName,
       this.userEmailAddress,
@@ -14,7 +16,7 @@ class FirestoreUser {
       this.userId,
       this.isAdmin});
 
-  FirestoreUser.fromJSON(Map<String, dynamic> json)
+  Transporter.fromJSON(Map<String, dynamic> json)
       : firstName = json['firstName'],
         lastName = json['lastName'],
         userEmailAddress = json['userEmailAddress'],
@@ -42,7 +44,7 @@ class FirestoreUser {
 
   @override
   bool operator ==(other) {
-    return (other is FirestoreUser) &&
+    return (other is Transporter) &&
         other.firstName == firstName &&
         other.lastName == lastName &&
         other.userEmailAddress == userEmailAddress &&

--- a/app/lib/core/services/authentication/auth_service.dart
+++ b/app/lib/core/services/authentication/auth_service.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:app/core/models/firestore_user.dart';
+import 'package:app/core/models/transporter.dart';
 import 'package:app/core/utilities/optional.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -49,7 +49,7 @@ class AuthenticationService {
             email: userEmailAddress,
             password: password,
           )
-          .then((authResult) => addUserToFirestore(FirestoreUser(
+          .then((authResult) => addTransporterToFirestore(Transporter(
                 userId: authResult.user.uid,
                 firstName: firstName,
                 lastName: lastName,
@@ -59,7 +59,7 @@ class AuthenticationService {
                 isAdmin: false,
               )));
 
-  Future<void> addUserToFirestore(FirestoreUser user) async =>
+  Future<void> addTransporterToFirestore(Transporter user) async =>
       firebaseFirestore.collection('users').doc(user.userId).set(user.toJSON());
 
   Future<void> signOut() async => firebaseAuth.signOut();

--- a/app/lib/core/services/authentication/auth_service.dart
+++ b/app/lib/core/services/authentication/auth_service.dart
@@ -1,19 +1,35 @@
 import 'dart:async';
 
 import 'package:app/core/models/firestore_user.dart';
+import 'package:app/core/utilities/optional.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
+/// A service wrapping FirebaseAuth
+/// Sign in persistence is guaranteed default as per https://firebase.flutter.dev/docs/auth/usage/#persisting-authentication-state
 class AuthenticationService {
   final FirebaseAuth firebaseAuth;
   final FirebaseFirestore firebaseFirestore;
-  FirestoreUser _currentUser;
 
-  FirestoreUser get currentUser => _currentUser;
+  // The logged in user information is the same as the Transporter information
+  // but separate for Firebase Authentication
+  Optional<User> _currentUser;
+
+  Optional<User> get currentUser => _currentUser;
+
+  // Stream available to any class needing to listen actively to changes
+  Stream<Optional<User>> currentUserChanges() => firebaseAuth
+      .authStateChanges()
+      .map((User user) => _currentUser = Optional.of(user));
 
   AuthenticationService(
-      {@required this.firebaseAuth, @required this.firebaseFirestore});
+      {@required this.firebaseAuth, @required this.firebaseFirestore}) {
+    // Internal stream to update the one-time get currentUser
+    firebaseAuth
+        .authStateChanges()
+        .listen((User user) => _currentUser = Optional.of(user));
+  }
 
   Future<UserCredential> signIn({
     @required String email,

--- a/app/lib/core/services/database/database_interface.dart
+++ b/app/lib/core/services/database/database_interface.dart
@@ -4,15 +4,15 @@ import 'package:app/core/models/atr_identifier.dart';
 import 'package:app/core/models/contingency_plan_info.dart';
 import 'package:app/core/models/delivery_info.dart';
 import 'package:app/core/models/feed_water_rest_info.dart';
-import 'package:app/core/models/firestore_user.dart';
 import 'package:app/core/models/loading_vehicle_info.dart';
 import 'package:app/core/models/shipper_info.dart';
+import 'package:app/core/models/transporter.dart';
 import 'package:app/core/models/transporter_info.dart';
 
 abstract class DatabaseInterface {
-  Future<void> setNewUser(FirestoreUser newUser);
+  Future<void> setNewTransporter(Transporter newTransporter);
 
-  Future<FirestoreUser> getUser(String userId);
+  Future<Transporter> getTransporter(String userId);
 
   Future<AnimalTransportRecord> setNewAtr(String userId);
 

--- a/app/lib/core/services/database/database_service.dart
+++ b/app/lib/core/services/database/database_service.dart
@@ -6,9 +6,9 @@ import 'package:app/core/models/atr_identifier.dart';
 import 'package:app/core/models/contingency_plan_info.dart';
 import 'package:app/core/models/delivery_info.dart';
 import 'package:app/core/models/feed_water_rest_info.dart';
-import 'package:app/core/models/firestore_user.dart';
 import 'package:app/core/models/loading_vehicle_info.dart';
 import 'package:app/core/models/shipper_info.dart';
+import 'package:app/core/models/transporter.dart';
 import 'package:app/core/models/transporter_info.dart';
 import 'package:app/core/services/database/database_interface.dart';
 
@@ -17,11 +17,11 @@ class DatabaseService {
 
   DatabaseService(this.interface);
 
-  Future<FirestoreUser> getUser(String userId) async =>
-      interface.getUser(userId);
+  Future<Transporter> getTransporter(String userId) async =>
+      interface.getTransporter(userId);
 
-  Future<void> newUser(FirestoreUser newUser) async =>
-      interface.setNewUser(newUser);
+  Future<void> newTransporter(Transporter newUser) async =>
+      interface.setNewTransporter(newUser);
 
   Future<AnimalTransportRecord> saveNewAtr(String userId) async =>
       interface.setNewAtr(userId);
@@ -58,8 +58,7 @@ class DatabaseService {
           String atrId, AcknowledgementInfo acknowledgementInfo) async =>
       interface.setAckInfo(atrId, acknowledgementInfo);
 
-  Future<bool> removeAtr(String atrId) async =>
-      interface.removeAtr(atrId).then((_) => true).catchError((_) => false);
+  Future<void> removeAtr(String atrId) async => interface.removeAtr(atrId);
 
   Future<List<AnimalTransportRecord>> getActiveRecords() async =>
       interface.getActiveRecords();

--- a/app/lib/core/services/database/firebase_database_interface.dart
+++ b/app/lib/core/services/database/firebase_database_interface.dart
@@ -6,9 +6,9 @@ import 'package:app/core/models/atr_identifier.dart';
 import 'package:app/core/models/contingency_plan_info.dart';
 import 'package:app/core/models/delivery_info.dart';
 import 'package:app/core/models/feed_water_rest_info.dart';
-import 'package:app/core/models/firestore_user.dart';
 import 'package:app/core/models/loading_vehicle_info.dart';
 import 'package:app/core/models/shipper_info.dart';
+import 'package:app/core/models/transporter.dart';
 import 'package:app/core/models/transporter_info.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
@@ -20,16 +20,15 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
   FirebaseDatabaseInterface(this._firestore);
 
   @override
-  Future<FirestoreUser> getUser(String userId) async => _firestore
-      .collection('users')
-      .doc(userId)
-      .get()
-      .then((DocumentSnapshot snapshot) =>
-          FirestoreUser.fromJSON(snapshot.data()));
+  Future<Transporter> getTransporter(String userId) async =>
+      _firestore.collection('transporter').doc(userId).get().then(
+          (DocumentSnapshot snapshot) => Transporter.fromJSON(snapshot.data()));
 
   @override
-  Future<void> setNewUser(FirestoreUser newUser) async =>
-      _firestore.collection('users').doc(newUser.userId).set(newUser.toJSON());
+  Future<void> setNewTransporter(Transporter newTransporter) async => _firestore
+      .collection('transporter')
+      .doc(newTransporter.userId)
+      .set(newTransporter.toJSON());
 
   @override
   Future<List<AnimalTransportRecord>> getCompleteRecords() async => _firestore

--- a/app/lib/test/test_json.dart
+++ b/app/lib/test/test_json.dart
@@ -1,6 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-Map<String, dynamic> testFireStoreUserJson() => {
+Map<String, dynamic> testTransporterJson() => {
       'firstName': 'clark',
       'lastName': 'sasa',
       'userEmailAddress': 'sasasass',

--- a/app/lib/ui/routes/main_navigator/app_route_generator.dart
+++ b/app/lib/ui/routes/main_navigator/app_route_generator.dart
@@ -17,6 +17,9 @@ class AppRouteGenerator {
            These routes will be pushed on top of the root route.
          */
         switch (settings.name) {
+          // TODO: #186. Prevent routing to certain screens when not logged in
+          // Each screen could also listen to auth changes and boot bad Users
+          // That's could be excessive, however.
           case WelcomeScreen.route:
             return WelcomeScreen();
           case SignInScreen.route:

--- a/app/lib/ui/views/active/atr_editing_screen.dart
+++ b/app/lib/ui/views/active/atr_editing_screen.dart
@@ -109,6 +109,11 @@ class _ATREditingScreenState extends State<ATREditingScreen> {
     ]);
   }
 
+  // TODO: #178. Make saves occur on screen exit.
+  // Also need to update FormField to stop using onChanged. Save CPU use.
+  // Also need to add the "new" atr button in meantime on NewScreen until
+  // #119 is addressed
+
   void _submitATR() {
     // TODO: #178. Call service and submit the completed atr
     widget._dialogService


### PR DESCRIPTION
In this PR I have:
1. Changed some things in `AuthService` so we can listen to the current user changes (sign in, sign out)
2. Changed `FirestoreUser` to `Transporter` (lol). This means that the `User` of the application is a `Transporter`, too.
> A `User` is a `FirebaseAuth` user, not necessarily a transporter
3. Slapped TODOs where I think they're needed (for me mostly)

These changes aren't breaking, but I'll ad-hoc test them once Sana's recent PR is merged #187 . 

These changes are related to work in #186 and #162  and #178 .
