### PR TITLE
Update AuthService to provide current user changes. Check if user is logged in on some screens.

### DIFF
--- a/app/lib/core/services/authentication/auth_service.dart
+++ b/app/lib/core/services/authentication/auth_service.dart
@@ -20,7 +20,7 @@ class AuthenticationService {
 
   // The logged in user information is the same as the Transporter information
   // but separate for Firebase Authentication
-  Optional<User> _currentUser = Optional.empty();
+  Optional<User> _currentUser;
 
   Optional<User> get currentUser => _currentUser;
 
@@ -36,6 +36,7 @@ class AuthenticationService {
   }
 
   AuthenticationService({@required this.firebaseAuth}) {
+    _currentUser = Optional.of(firebaseAuth.currentUser);
     currentUserChanges = _currentUserChangesStream.stream;
     _authStateChanges =
         firebaseAuth.authStateChanges().listen((User userMaybe) async {

--- a/app/lib/core/view_models/history_screen_view_model.dart
+++ b/app/lib/core/view_models/history_screen_view_model.dart
@@ -3,10 +3,13 @@ import 'dart:async';
 import 'package:app/core/models/animal_transport_record.dart';
 import 'package:app/core/services/authentication/auth_service.dart';
 import 'package:app/core/services/database/database_service.dart';
+import 'package:app/core/services/dialog/dialog_service.dart';
 import 'package:app/core/services/navigation/nav_service.dart';
 import 'package:app/core/services/service_locator.dart';
+import 'package:app/core/utilities/optional.dart';
 import 'package:app/core/view_models/base_view_model.dart';
 import 'package:app/ui/widgets/utility/pdf_screen.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -14,31 +17,48 @@ import 'package:flutter/material.dart';
 class HistoryScreenViewModel extends BaseViewModel {
   final NavigationService _navigationService = locator<NavigationService>();
   final DatabaseService _databaseService = locator<DatabaseService>();
+  final DialogService _dialogService = locator<DialogService>();
   final AuthenticationService _authenticationService =
       locator<AuthenticationService>();
-  final List<AnimalTransportRecord> _animalTransportRecords = [];
+  StreamSubscription<Optional<User>> _currentUserSubscription;
   StreamSubscription<List<AnimalTransportRecord>> _atrSubscription;
+
+  final List<AnimalTransportRecord> _animalTransportRecords = [];
 
   List<AnimalTransportRecord> get animalTransportRecords =>
       List.unmodifiable(_animalTransportRecords);
 
   HistoryScreenViewModel() {
-    _atrSubscription = _databaseService
-        .getUpdatedCompleteATRs(_authenticationService.currentUser.get().uid)
-        .listen((atrs) {
-      removeAll();
-      addAll(atrs);
-    });
+    final thisUser = _authenticationService.currentUser;
+    if (thisUser.isPresent()) {
+      _atrSubscription = _databaseService
+          .getUpdatedCompleteATRs(thisUser.get().uid)
+          .listen((atrs) {
+        removeAll();
+        addAll(atrs);
+      });
+      _currentUserSubscription = _authenticationService.currentUserChanges
+          .listen((Optional<User> user) {
+        // User has logged out or is no longer authenticated, lock the ViewModel
+        if (!user.isPresent()) _cancelAtrSubscription();
+      });
+    } else {
+      _dialogService.showDialog(
+        title: 'Launching the history screen failed',
+        description: "You are not logged in!",
+      );
+    }
   }
 
   void _cancelAtrSubscription() {
     removeAll();
-    _atrSubscription.cancel();
+    if (_atrSubscription != null) _atrSubscription.cancel();
   }
 
   @mustCallSuper
   void dispose() {
     _cancelAtrSubscription();
+    if (_currentUserSubscription != null) _currentUserSubscription.cancel();
     super.dispose();
   }
 

--- a/app/lib/core/view_models/new_screen_view_model.dart
+++ b/app/lib/core/view_models/new_screen_view_model.dart
@@ -16,6 +16,7 @@ class NewScreenViewModel extends BaseViewModel {
   void signOut() async {
     _authenticationService
         .signOut()
+        // TODO: Navigate to the welcome screen and pop other screens along the way
         .then((_) => _navigationService.pop())
         .catchError((error) => _dialogService.showDialog(
               title: 'Sign out failed',

--- a/app/lib/core/view_models/new_screen_view_model.dart
+++ b/app/lib/core/view_models/new_screen_view_model.dart
@@ -16,7 +16,7 @@ class NewScreenViewModel extends BaseViewModel {
   void signOut() async {
     _authenticationService
         .signOut()
-        // TODO: Navigate to the welcome screen and pop other screens along the way
+        // TODO: #162.  to the welcome screen and pop other screens along the way
         .then((_) => _navigationService.pop())
         .catchError((error) => _dialogService.showDialog(
               title: 'Sign out failed',

--- a/app/lib/core/view_models/new_screen_view_model.dart
+++ b/app/lib/core/view_models/new_screen_view_model.dart
@@ -23,20 +23,22 @@ class NewScreenViewModel extends BaseViewModel {
             ));
   }
 
-  Future<void> startNewAtr() async =>
-      _authenticationService.currentUser.isPresent()
-          ? _databaseService
-              .saveNewAtr(_authenticationService.currentUser.get().uid)
-              .then((atr) => _navigationService
-                  .navigateTo(ATREditingScreen.route, arguments: atr))
-              .catchError((e) => _dialogService.showDialog(
-                    title: 'Starting a new Animal Transport Record failed',
-                    description: e.message,
-                  ))
-          : _dialogService.showDialog(
-              title: 'Starting a new Animal Transport Record failed',
-              description: "You are not logged in!",
-            );
+  Future<void> startNewAtr() async {
+    final currentUser = _authenticationService.currentUser;
+    currentUser.isPresent()
+        ? _databaseService
+            .saveNewAtr(currentUser.get().uid)
+            .then((atr) => _navigationService.navigateTo(ATREditingScreen.route,
+                arguments: atr))
+            .catchError((e) => _dialogService.showDialog(
+                  title: 'Starting a new Animal Transport Record failed',
+                  description: e.message,
+                ))
+        : _dialogService.showDialog(
+            title: 'Starting a new Animal Transport Record failed',
+            description: "You are not logged in!",
+          );
+  }
 
   void navigateToNewScreen() => _navigationService.pop();
 }

--- a/app/lib/core/view_models/welcome_screen_view_model.dart
+++ b/app/lib/core/view_models/welcome_screen_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:app/core/services/authentication/auth_service.dart';
 import 'package:app/core/services/navigation/nav_service.dart';
 import 'package:app/core/services/service_locator.dart';
 import 'package:app/core/view_models/base_view_model.dart';
@@ -7,6 +8,12 @@ import 'package:app/ui/views/signup/sign_up_screen.dart';
 
 class WelcomeScreenViewModel extends BaseViewModel {
   final NavigationService _navigationService = locator<NavigationService>();
+  final AuthenticationService _authenticationService =
+      locator<AuthenticationService>();
+
+  void skipToHomeScreenIfLoggedIn() {
+    if (_authenticationService.currentUser.isPresent()) _navigateToHomeScreen();
+  }
 
   void navigateToSignInScreen() =>
       _navigationService.navigateTo(SignInScreen.route);
@@ -14,6 +21,6 @@ class WelcomeScreenViewModel extends BaseViewModel {
   void navigateToSignUpScreen() =>
       _navigationService.navigateTo(SignUpScreen.route);
 
-  void navigateToHomeScreen() =>
+  void _navigateToHomeScreen() =>
       _navigationService.navigateTo(HomeScreen.route);
 }

--- a/app/lib/ui/views/active/active_screen.dart
+++ b/app/lib/ui/views/active/active_screen.dart
@@ -28,16 +28,20 @@ class _ActiveScreenState extends State<ActiveScreen> {
         automaticallyImplyLeading: false,
       ),
       body: TemplateBaseViewModel<ActiveScreenViewModel>(
-        builder: (context, model, _) => GridView.builder(
-          itemCount: model.animalTransportRecords.length,
-          itemBuilder: (context, index) =>
-              createPreview(model, model.animalTransportRecords[index]),
-          gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-              maxCrossAxisExtent: 200,
-              childAspectRatio: 3 / 2,
-              crossAxisSpacing: 20,
-              mainAxisSpacing: 20),
-        ),
+        builder: (context, model, _) => model.animalTransportRecords.isEmpty
+            ? ListTile(
+                title: Text("No active Animal Transport Records"),
+                subtitle: Text("You can add some using the \"New\" button"))
+            : GridView.builder(
+                itemCount: model.animalTransportRecords.length,
+                itemBuilder: (context, index) =>
+                    createPreview(model, model.animalTransportRecords[index]),
+                gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+                    maxCrossAxisExtent: 200,
+                    childAspectRatio: 3 / 2,
+                    crossAxisSpacing: 20,
+                    mainAxisSpacing: 20),
+              ),
       ),
     );
   }

--- a/app/lib/ui/views/history/history_screen.dart
+++ b/app/lib/ui/views/history/history_screen.dart
@@ -32,16 +32,21 @@ class _HistoryScreenState extends State<HistoryScreen> {
         automaticallyImplyLeading: false,
       ),
       body: TemplateBaseViewModel<HistoryScreenViewModel>(
-          builder: (context, model, _) => GridView.builder(
-                itemCount: model.animalTransportRecords.length,
-                itemBuilder: (_, index) =>
-                    createPreview(model.animalTransportRecords[index]),
-                gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-                    maxCrossAxisExtent: 200,
-                    childAspectRatio: 3 / 2,
-                    crossAxisSpacing: 20,
-                    mainAxisSpacing: 20),
-              )),
+          builder: (context, model, _) => model.animalTransportRecords.isEmpty
+              ? ListTile(
+                  title: Text("No completed Animal Transport Records"),
+                  subtitle:
+                      Text("Submitted completed records will appear here"))
+              : GridView.builder(
+                  itemCount: model.animalTransportRecords.length,
+                  itemBuilder: (_, index) =>
+                      createPreview(model.animalTransportRecords[index]),
+                  gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+                      maxCrossAxisExtent: 200,
+                      childAspectRatio: 3 / 2,
+                      crossAxisSpacing: 20,
+                      mainAxisSpacing: 20),
+                )),
     );
   }
 }

--- a/app/lib/ui/views/welcome/welcome_screen.dart
+++ b/app/lib/ui/views/welcome/welcome_screen.dart
@@ -11,7 +11,10 @@ class WelcomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TemplateBaseViewModel<WelcomeScreenViewModel>(
-      builder: (context, model, child) => Scaffold(
+        builder: (context, model, child) {
+      WidgetsBinding.instance
+          .addPostFrameCallback((_) => model.skipToHomeScreenIfLoggedIn());
+      return Scaffold(
         appBar: AppBar(),
         body: Center(
           child: Column(
@@ -29,7 +32,7 @@ class WelcomeScreen extends StatelessWidget {
             ],
           ),
         ),
-      ),
-    );
+      );
+    });
   }
 }

--- a/app/test/core/services/authentication/auth_service_test.dart
+++ b/app/test/core/services/authentication/auth_service_test.dart
@@ -54,6 +54,7 @@ void main() {
     test('sign up successful calls add transporter', () async {
       setUpAuthChangesMockUser();
       setUpFirebaseAuthMock();
+      when(mockFirebaseAuth.currentUser).thenReturn(null);
       when(mockDatabaseService.addTransporter(any))
           .thenAnswer((_) => Future.value()); // do nothing for test
       final authService = AuthenticationService(firebaseAuth: mockFirebaseAuth);
@@ -77,6 +78,7 @@ void main() {
 
     test('sign up failed, create user failed', () async {
       setUpAuthChangesMockUser();
+      when(mockFirebaseAuth.currentUser).thenReturn(null);
       when(mockFirebaseAuth.createUserWithEmailAndPassword(
               email: userEmailAddress, password: password))
           .thenAnswer((_) async => Future.error('Error Here'));
@@ -94,6 +96,7 @@ void main() {
 
     test('delete account failed, not logged in', () async {
       setUpAuthChangesMockUser();
+      when(mockFirebaseAuth.currentUser).thenReturn(null);
       try {
         await AuthenticationService(firebaseAuth: mockFirebaseAuth)
             .deleteAccount();
@@ -106,10 +109,18 @@ void main() {
         'current user stream updates when current user changes, getCurrentUser updates too',
         () async {
       setUpAuthChangesMockUser();
+      when(mockFirebaseAuth.currentUser).thenReturn(null);
       final authService = AuthenticationService(firebaseAuth: mockFirebaseAuth);
 
-      expectLater(authService.currentUserChanges,
-          emitsInOrder([Optional.of(mockUser), Optional.empty()]));
+      expectLater(
+          authService.currentUserChanges,
+          emitsInOrder(
+              [Optional.empty(), Optional.of(mockUser), Optional.empty()]));
+
+      // Start state
+      mockAuthStateChangesController.add(null);
+      // Let changes propagate
+      await Future.value(Duration(milliseconds: 1));
 
       mockAuthStateChangesController.add(mockUser);
       // Let changes propagate

--- a/app/test/main_test.dart
+++ b/app/test/main_test.dart
@@ -1,20 +1,30 @@
+import 'package:app/core/services/authentication/auth_service.dart';
 import 'package:app/core/services/dialog/dialog_service.dart';
 import 'package:app/core/services/navigation/nav_service.dart';
+import 'package:app/core/utilities/optional.dart';
 import 'package:app/core/view_models/welcome_screen_view_model.dart';
 import 'package:app/humane_transport_app.dart';
 import 'package:app/test/mock/test_service_locator.dart';
 import 'package:app/ui/views/welcome/welcome_screen.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
+import 'package:mockito/mockito.dart';
+
+class MockAuthenticationService extends Mock implements AuthenticationService {}
 
 final testLocator = GetIt.instance;
 
 void main() {
+  final mockAuthService = MockAuthenticationService();
+
   group('Application main', () {
     tearDown(() async => resetForTest(testLocator));
 
     testWidgets('first route is welcome screen', (WidgetTester tester) async {
-      addLazySingletonForTest(testLocator, () => WelcomeScreenViewModel());
+      testLocator
+          .registerLazySingleton<AuthenticationService>(() => mockAuthService);
+      when(mockAuthService.currentUser).thenReturn(Optional.empty());
+      addFactoryForTest(testLocator, () => WelcomeScreenViewModel());
       addLazySingletonForTest(testLocator, () => NavigationService());
       addLazySingletonForTest(testLocator, () => DialogService());
       await tester.pumpWidget(HumaneTransportApp());


### PR DESCRIPTION
Closes #186 .

This PR:
1. Addresses a few bugs with the last PR I made
> On signout, the living viewmodels scrap listening to atr updates and user changes before destruction now.
2. Made `AuthService` provide just `FirebaseAuth` changes.
> @MummenRider 's open PR #193 has Transporter changes through the database, which is correct and the way I should have done it.
3. Made `ViewModel`s listen to `AuthService` for active user changes where needed
> Changed any buttons with the one-time get of logged in user, and made any dynamic listening screens stop when user logs out (this prevents unwanted changes due to some bug that keeps the user on the screen when logged out)

There are still unfortunately some bugs due to navigation. Particularly, when the user closes the app and opens it again, if they are logged in we do indeed skip to the home page, but if they sign out after, the app gets mad because the screen to pop to lost it's state (`SignInScreen`).