### PR TITLE
Update README with actions badges, documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
 # Humane Transport
+![Build and integration tests](https://github.com/holtzmak/Humane-Transport/actions/workflows/flutter-action-build-and-integration-testing.yml/badge.svg)
+![Formatting and Unit tests](https://github.com/holtzmak/Humane-Transport/actions/workflows/flutter-action-formatting-and-unit-testing.yml/badge.svg)
 
-A mobile application to record Canadian animal transport and transfer of care documentation, meeting the [requirements and regulations](https://www.inspection.gc.ca/animal-health/humane-transport/eng/1300460032193/1300460096845) set out by the Canadian Food Inspection Agency (CFIA).
+A [Flutter](https://flutter.dev/) and [Firebase](https://firebase.google.com/) mobile application to record Canadian animal transport and transfer of care documentation, meeting the [requirements and regulations](https://www.inspection.gc.ca/animal-health/humane-transport/eng/1300460032193/1300460096845) set out by the Canadian Food Inspection Agency (CFIA).
+
+**This project's main source of information is the [Wiki](https://github.com/holtzmak/Humane-Transport/wiki).** See our Wiki for the following information and more:
+1. Team meeting minutes (Scrum dates and discussion minutes)
+2. Our breakdown of the Animal Transport Record into a digital-friendly format and process, including [User Story/Journey Maps](https://www.nngroup.com/articles/user-story-mapping/)
+3. Our application architecture and software design documents, including [C4 Modeling Diagrams](https://c4model.com/)
+
+Further documentation and diagrams are available in the [`documentation` folder in the codebase](https://github.com/holtzmak/Humane-Transport/tree/master/documentation).
 
 ***
 
-## Project Information
+## Installation and Use
 
-This project's main source of background information, process- and requirements-related documentation, architectural- and design-related documentation, and project discussion is the [Wiki](https://github.com/holtzmak/Humane-Transport/wiki).
+ **_Instructions for installing and using this application TBD_** 
+
+## Project Abstract
+
+Canadian livestock transporters are required to follow rules and regulations specified by the Canadian Food Inspection Agency (CFIA) before, during, and after animal transport. The current process requires paper manifests to be created and maintained by transporters to ensure that all animals and their data are collected for business, market, and tracing purposes; it is not well suited to transporters who may not have access to materials while on the road. Humane Transport is a mobile application which provides transporters with a paper-free way to collect and provide all CFIA required data while meeting the requirements of the Health of Animals Regulations Part XII, Humane transport of animals (sections 136-155), and providing access to interpretive guidance documentation to assist understanding.
 
 ## Project Deliverables
 
@@ -22,7 +35,8 @@ The deliverables assigned and set out by our post-seconday software engineering 
 1. Team/Instructor Scrum Report 3 [Slides](https://sanakhan1997.github.io/Humane-Transport/) (November 23, 2020)
 1. Project Progress Vlog 3 [Video](https://youtu.be/hMpPf16VFHM) and [Slides](https://sanakhan1997.github.io/Humane-Transport/) (December 14, 2020)
 1. Team/Instructor Scrum Report 4 [Slides](https://sanakhan1997.github.io/Humane-Transport/) (January 21, 2021)
-1. Project Progress Vlog 4 [Video](https://youtu.be/BHDtMDXqNDQ) and [Slides](https://sanakhan1997.github.io/Humane-Transport/) (February 04, 2021)
+1. Project Progress Vlog 4 [Video](https://youtu.be/BHDtMDXqNDQ) and [Slides](https://sanakhan1997.github.io/Humane-Transport/) (February 4, 2021)
+1. Team/Instructor Scrum Report 5 [Slides](https://sanakhan1997.github.io/Humane-Transport/) (March 4, 2021)
 
 ***
 


### PR DESCRIPTION
Closes #88 .

In this PR I have added:
1. Build status badges
2. References to our documentation available in the wiki
3. References to what our application framework and database are
4. Updated deliverables
5. Added a spot for installation and use instructions we'll likely add in Sprint 10

I have not yet split up the build files or added [the line coverage badge](https://dev.to/3lvv0w/testing-on-flutter-generate-unit-test-badge-using-lcov-to-your-repository-4ea4) (this requires some more work but I'd rather develop ATM).