### PR TITLE
Bring back bottom nav on active and history screens

### DIFF
--- a/app/lib/core/view_models/active_screen_view_model.dart
+++ b/app/lib/core/view_models/active_screen_view_model.dart
@@ -10,6 +10,7 @@ import 'package:app/core/utilities/optional.dart';
 import 'package:app/core/view_models/base_view_model.dart';
 import 'package:app/ui/common/view_state.dart';
 import 'package:app/ui/views/active/atr_editing_screen.dart';
+import 'package:app/ui/views/history/history_screen.dart';
 import 'package:app/ui/views/home_screen.dart';
 import 'package:date_time_picker/date_time_picker.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -80,8 +81,27 @@ class ActiveScreenViewModel extends BaseViewModel {
   void navigateToHomeScreen() =>
       _navigationService.navigateBackUntil(HomeScreen.route);
 
+  void navigateToHistoryScreen() =>
+      _navigationService.navigateAndReplace(HistoryScreen.route);
+
   void navigateToEditingScreen(AnimalTransportRecord atr) {
     _navigationService.navigateTo(ATREditingScreen.route, arguments: atr);
+  }
+
+  Future<void> startNewAtr() async {
+    final currentUser = _authenticationService.currentUser;
+    currentUser.isPresent()
+        ? _databaseService
+            .saveNewAtr(currentUser.get().uid)
+            .then((atr) => navigateToEditingScreen(atr))
+            .catchError((e) => _dialogService.showDialog(
+                  title: 'Starting a new Animal Transport Record failed',
+                  description: e.message,
+                ))
+        : _dialogService.showDialog(
+            title: 'Starting a new Animal Transport Record failed',
+            description: "You are not logged in!",
+          );
   }
 
   Future<void> saveEditedAtr(AnimalTransportRecord atr) async {

--- a/app/lib/core/view_models/history_screen_view_model.dart
+++ b/app/lib/core/view_models/history_screen_view_model.dart
@@ -8,6 +8,7 @@ import 'package:app/core/services/nav_service.dart';
 import 'package:app/core/services/service_locator.dart';
 import 'package:app/core/utilities/optional.dart';
 import 'package:app/core/view_models/base_view_model.dart';
+import 'package:app/ui/views/active/active_screen.dart';
 import 'package:app/ui/views/history/atr_display_screen.dart';
 import 'package:app/ui/views/history/history_screen.dart';
 import 'package:app/ui/views/home_screen.dart';
@@ -85,4 +86,7 @@ class HistoryScreenViewModel extends BaseViewModel {
 
   void navigateToHistoryScreen() =>
       _navigationService.navigateBackUntil(HistoryScreen.route);
+
+  void navigateToActiveScreen() =>
+      _navigationService.navigateAndReplace(ActiveScreen.route);
 }

--- a/app/lib/ui/views/account/account_screen.dart
+++ b/app/lib/ui/views/account/account_screen.dart
@@ -17,74 +17,56 @@ class AccountScreen extends StatelessWidget {
                   margin: EdgeInsets.all(20.0),
                   child: Column(
                     children: [
-                      Row(
+                      ListTile(
+                        leading: Icon(
+                          Icons.account_circle_sharp,
+                          size: 30.0,
+                          color: Colors.green[400],
+                        ),
+                        title: Text(
+                          '${model.transporter.firstName} ${model.transporter.lastName}',
+                          style: TextStyle(fontSize: 15.0),
+                        ),
+                        trailing: ElevatedButton(
+                          onPressed: () =>
+                              model.navigateToAccountEditingScreen(),
+                          child: Text('Edit'),
+                        ),
+                      ),
+                      Padding(
+                        padding: EdgeInsets.only(top: 20.0),
+                      ),
+                      Table(
+                        border: TableBorder.all(color: Colors.black12),
                         children: [
-                          Container(
-                            child: Icon(
-                              Icons.account_circle_sharp,
-                              size: 30.0,
-                              color: Colors.green[400],
+                          TableRow(children: [
+                            ListTile(
+                              leading: Icon(
+                                Icons.call,
+                                size: 30.0,
+                                color: Colors.green[400],
+                              ),
+                              title: Text(
+                                '${model.transporter.userPhoneNumber}',
+                                style: TextStyle(fontSize: 15.0),
+                              ),
                             ),
-                          ),
-                          SizedBox(width: 30.0),
-                          Text(
-                            '${model.transporter.firstName} ${model.transporter.lastName}',
-                            style: TextStyle(fontSize: 15.0),
-                          ),
-                          SizedBox(width: 100.0),
+                          ]),
+                          TableRow(children: [
+                            ListTile(
+                              leading: Icon(
+                                Icons.markunread,
+                                size: 30.0,
+                                color: Colors.green[400],
+                              ),
+                              title: Text(
+                                '${model.transporter.userEmailAddress} ',
+                                style: TextStyle(fontSize: 15.0),
+                              ),
+                            ),
+                          ])
                         ],
                       ),
-                      Divider(
-                        height: 40,
-                        thickness: 2,
-                        color: Colors.black12,
-                      ),
-                      Row(
-                        children: [
-                          Container(
-                            child: Icon(
-                              Icons.call,
-                              size: 30.0,
-                              color: Colors.green[400],
-                            ),
-                          ),
-                          SizedBox(width: 30.0),
-                          Text(
-                            '${model.transporter.userPhoneNumber}',
-                            style: TextStyle(fontSize: 15.0),
-                          ),
-                        ],
-                      ),
-                      Divider(
-                        height: 40,
-                        thickness: 2,
-                        color: Colors.black12,
-                      ),
-                      Row(
-                        children: [
-                          Container(
-                            child: Icon(
-                              Icons.markunread,
-                              size: 30.0,
-                              color: Colors.green[400],
-                            ),
-                          ),
-                          SizedBox(width: 30.0),
-                          Text(
-                            '${model.transporter.userEmailAddress} ',
-                            style: TextStyle(fontSize: 15.0),
-                          ),
-                        ],
-                      ),
-                      Divider(
-                        height: 40,
-                        thickness: 2,
-                        color: Colors.black12,
-                      ),
-                      ElevatedButton(
-                        onPressed: () => model.navigateToAccountEditingScreen(),
-                        child: Text('Edit'),
-                      )
                     ],
                   ),
                 ),

--- a/app/lib/ui/views/active/active_screen.dart
+++ b/app/lib/ui/views/active/active_screen.dart
@@ -27,11 +27,32 @@ class _ActiveScreenState extends State<ActiveScreen> {
         appBar: AppBar(
           title: Text('Active Screen'),
           automaticallyImplyLeading: false,
-          leading: new IconButton(
-            icon: new Icon(Icons.arrow_back_ios),
-            onPressed: model.navigateToHomeScreen,
-          ),
         ),
+        bottomNavigationBar: BottomNavigationBar(
+            onTap: (int item) async {
+              switch (item) {
+                case 0:
+                  return model.navigateToHomeScreen();
+                case 1:
+                  return model.navigateToHistoryScreen();
+                case 2:
+                  return model.startNewAtr();
+              }
+            },
+            items: [
+              BottomNavigationBarItem(
+                icon: Icon(Icons.arrow_back),
+                label: "Back",
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.access_time),
+                label: "History",
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.add_circle),
+                label: "Add New",
+              )
+            ]),
         body: model.animalTransportRecords.isEmpty
             ? ListTile(
                 title: Text("No active Animal Transport Records"),

--- a/app/lib/ui/views/active/active_screen.dart
+++ b/app/lib/ui/views/active/active_screen.dart
@@ -50,7 +50,7 @@ class _ActiveScreenState extends State<ActiveScreen> {
               ),
               BottomNavigationBarItem(
                 icon: Icon(Icons.add_circle),
-                label: "Add New",
+                label: "New Form",
               )
             ]),
         body: model.animalTransportRecords.isEmpty

--- a/app/lib/ui/views/active/atr_editing_screen.dart
+++ b/app/lib/ui/views/active/atr_editing_screen.dart
@@ -150,7 +150,7 @@ class _ATREditingScreenState extends State<ATREditingScreen> {
                       title: Text("Animal Transport Form"),
                       automaticallyImplyLeading: false,
                       leading: new IconButton(
-                        icon: new Icon(Icons.arrow_back_ios),
+                        icon: new Icon(Icons.arrow_back),
                         onPressed: () async => _saveATR(model)
                             .then((value) => model.navigateBack()),
                       ),

--- a/app/lib/ui/views/history/atr_display_screen.dart
+++ b/app/lib/ui/views/history/atr_display_screen.dart
@@ -56,7 +56,7 @@ class _ATRDisplayScreenState extends State<ATRDisplayScreen> {
                 ],
                 automaticallyImplyLeading: false,
                 leading: new IconButton(
-                  icon: new Icon(Icons.arrow_back_ios),
+                  icon: new Icon(Icons.arrow_back),
                   onPressed: model.navigateToHistoryScreen,
                 ),
               ),

--- a/app/lib/ui/views/history/history_screen.dart
+++ b/app/lib/ui/views/history/history_screen.dart
@@ -27,11 +27,26 @@ class _HistoryScreenState extends State<HistoryScreen> {
           appBar: AppBar(
             title: Text('History Screen'),
             automaticallyImplyLeading: false,
-            leading: new IconButton(
-              icon: new Icon(Icons.arrow_back_ios),
-              onPressed: model.navigateToHomeScreen,
-            ),
           ),
+          bottomNavigationBar: BottomNavigationBar(
+              onTap: (int item) async {
+                switch (item) {
+                  case 0:
+                    return model.navigateToHomeScreen();
+                  case 1:
+                    return model.navigateToActiveScreen();
+                }
+              },
+              items: [
+                BottomNavigationBarItem(
+                  icon: Icon(Icons.arrow_back),
+                  label: "Back",
+                ),
+                BottomNavigationBarItem(
+                  icon: Icon(Icons.directions_car),
+                  label: "Active",
+                ),
+              ]),
           body: model.animalTransportRecords.isEmpty
               ? ListTile(
                   title: Text("No completed Animal Transport Records"),

--- a/app/lib/ui/views/welcome_screen.dart
+++ b/app/lib/ui/views/welcome_screen.dart
@@ -13,7 +13,9 @@ class WelcomeScreen extends StatelessWidget {
     return TemplateBaseViewModel<WelcomeScreenViewModel>(
         builder: (context, model, child) {
       return Scaffold(
-        appBar: AppBar(),
+        appBar: AppBar(
+          automaticallyImplyLeading: false,
+        ),
         body: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -126,7 +126,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.6.0"
+    version: "3.7.0"
   collection:
     dependency: transitive
     description:

--- a/app/test/ui/views/active/atr_editing_screen_test.dart
+++ b/app/test/ui/views/active/atr_editing_screen_test.dart
@@ -123,7 +123,7 @@ void main() {
     testWidgets('gives saved ATR to view model on exit, then exits',
         (WidgetTester tester) async {
       final testATR = testAnimalTransportRecord();
-      final backButtonFinder = find.byIcon(Icons.arrow_back_ios);
+      final backButtonFinder = find.byIcon(Icons.arrow_back);
       when(mockActiveScreenViewModel.saveEditedAtr(testATR))
           .thenAnswer((_) => Future.value()); // do nothing for test
 
@@ -142,7 +142,7 @@ void main() {
               testFwrInfo(lastFwrLocation: testAddress(city: "Yellowknife")));
       final editedATR = testAnimalTransportRecord(
           fwrInfo: testFwrInfo(lastFwrLocation: testAddress(city: "Iqaluit")));
-      final backButtonFinder = find.byIcon(Icons.arrow_back_ios);
+      final backButtonFinder = find.byIcon(Icons.arrow_back);
       final fieldFinder = find.widgetWithText(TextFormField, "Yellowknife");
       when(mockActiveScreenViewModel.saveEditedAtr(testATR))
           .thenAnswer((_) => Future.value()); // do nothing for test


### PR DESCRIPTION
Closes #163 .

This PR:
1. Adjusts account screen
2. Brings back bottom nav bar for the screens that use it. Editing screens do not have a nav bar
3. Makes icons consistent across app

Changes look like:


https://user-images.githubusercontent.com/32527219/110716899-ad421500-81cd-11eb-8539-921fa8b2d546.mp4

