### PR TITLE
Update form fields for validation

### DIFF
--- a/app/lib/core/models/contingency_plan_info.dart
+++ b/app/lib/core/models/contingency_plan_info.dart
@@ -278,7 +278,7 @@ class ContingencyPlanEvent {
 
 @immutable
 class ContingencyActivity {
-  final TimeOfDay time;
+  final DateTime time;
   final String personContacted;
   final String methodOfContact;
   final String instructionsGiven;
@@ -299,14 +299,15 @@ class ContingencyActivity {
   @override
   bool operator ==(other) {
     return (other is ContingencyActivity) &&
-        other.time == time &&
+        DateFormat("hh:mm").format(other.time) ==
+            DateFormat("hh:mm").format(time) &&
         other.personContacted == personContacted &&
         other.methodOfContact == methodOfContact &&
         other.instructionsGiven == instructionsGiven;
   }
 
   ContingencyActivity.fromJSON(Map<String, dynamic> json)
-      : time = TimeOfDay.fromDateTime(json['time'].toDate()),
+      : time = json['time'].toDate(),
         personContacted = json['personContacted'],
         methodOfContact = json['methodOfContact'],
         instructionsGiven = json['instructionsGiven'];
@@ -318,7 +319,8 @@ class ContingencyActivity {
         'instructionsGiven': instructionsGiven,
       };
 
-  String toString() => '''Time of communication: $time
+  String toString() =>
+      '''Time of communication: ${DateFormat("hh:mm").format(time)}
   Who was contacted: $personContacted
   Communication method used: $methodOfContact
   What instructions were given and decisions made with the guidance of emergency contacts reached: $instructionsGiven''';
@@ -328,7 +330,7 @@ class ContingencyActivity {
       ListTile(
           visualDensity: VisualDensity(horizontal: 0, vertical: -2),
           title: Text("Time of communication"),
-          subtitle: Text('$time')),
+          subtitle: Text('${DateFormat("hh:mm").format(time)}')),
       ListTile(
           visualDensity: VisualDensity(horizontal: 0, vertical: -2),
           title: Text("Who was contacted"),

--- a/app/lib/core/services/dialog_service.dart
+++ b/app/lib/core/services/dialog_service.dart
@@ -18,8 +18,8 @@ class DialogService {
   }
 
   Future<DialogResponse> showDialog({
-    String title,
-    String description,
+    @required String title,
+    @required String description,
     String buttonText = 'Ok',
   }) {
     _dialogCompleter = Optional(Completer<DialogResponse>());
@@ -32,8 +32,8 @@ class DialogService {
   }
 
   Future<DialogResponse> showConfirmationDialog(
-      {String title,
-      String description,
+      {@required String title,
+      @required String description,
       String confirmationText = 'Ok',
       String cancelText = 'Cancel'}) {
     _dialogCompleter = Optional(Completer<DialogResponse>());

--- a/app/lib/test/helper/test_contingency_activity_expectations.dart
+++ b/app/lib/test/helper/test_contingency_activity_expectations.dart
@@ -1,10 +1,10 @@
 import 'package:app/core/models/contingency_plan_info.dart';
-import 'package:app/ui/widgets/utility/date_time_picker.dart';
+import 'package:date_time_picker/date_time_picker.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void verifyContingencyActivityShown(ContingencyActivity infoExpected) {
   expect(
-      find.text(convertTimeOfDayToString(infoExpected.time)), findsOneWidget);
+      find.text(DateFormat('HH:mm').format(infoExpected.time)), findsOneWidget);
   expect(find.text(infoExpected.personContacted), findsOneWidget);
   expect(find.text(infoExpected.methodOfContact), findsOneWidget);
   expect(find.text(infoExpected.instructionsGiven), findsOneWidget);

--- a/app/lib/test/test_data.dart
+++ b/app/lib/test/test_data.dart
@@ -13,7 +13,6 @@ import 'package:app/core/models/shipper_info.dart';
 import 'package:app/core/models/transporter.dart';
 import 'package:app/core/models/transporter_info.dart';
 import 'package:app/core/utilities/optional.dart';
-import 'package:flutter/material.dart';
 
 testAddress(
         {String streetAddress,
@@ -223,13 +222,12 @@ testContingencyEvent(
         actionsTaken: actionsTaken ?? ["Wrapped in available bandages"]);
 
 testContingencyActivity(
-        {TimeOfDay time,
+        {DateTime time,
         String personContacted,
         String methodOfContact,
         String instructionsGiven}) =>
     ContingencyActivity(
-        time:
-            time ?? TimeOfDay.fromDateTime(DateTime.parse("2021-02-03 13:01")),
+        time: time ?? DateTime.parse("2021-02-03 13:01"),
         personContacted: personContacted ?? "Receiver",
         methodOfContact: methodOfContact ?? "Phone call",
         instructionsGiven: instructionsGiven ?? "Instructions");

--- a/app/lib/ui/views/active/dynamic_form_field/dynamic_animal_group_form_field.dart
+++ b/app/lib/ui/views/active/dynamic_form_field/dynamic_animal_group_form_field.dart
@@ -1,9 +1,8 @@
 import 'package:app/core/models/loading_vehicle_info.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
 import 'package:app/ui/views/active/form_field/animal_group_form_field.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
-
-import 'dynamic_form_field.dart';
 
 /// A custom form field for AnimalGroups.
 /// Due to it's dynamic nature this widget should only be used inside a grow-able
@@ -11,7 +10,7 @@ import 'dynamic_form_field.dart';
 dynamicAnimalGroupFormField(
         {@required List<AnimalGroup> initialList,
         @required Function(List<AnimalGroup>) onSaved}) =>
-    DynamicFormField<AnimalGroup, AnimalGroupFormField>(
+    DynamicFormField<AnimalGroup>(
         initialList: initialList,
         titles: "Animal(s) description",
         onSaved: onSaved,
@@ -29,6 +28,6 @@ dynamicAnimalGroupFormField(
             AnimalGroupFormField(
                 // Must have unique keys in rebuilding widget lists
                 key: ObjectKey(Uuid().v4()),
-                initialInfo: it,
+                initial: it,
                 onSaved: (AnimalGroup changed) => onSaved(index, changed),
                 onDelete: () => onDelete(index)));

--- a/app/lib/ui/views/active/dynamic_form_field/dynamic_compromised_animal_form_field.dart
+++ b/app/lib/ui/views/active/dynamic_form_field/dynamic_compromised_animal_form_field.dart
@@ -1,9 +1,8 @@
 import 'package:app/core/models/loading_vehicle_info.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
 import 'package:app/ui/views/active/form_field/compromised_animal_form_field.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
-
-import 'dynamic_form_field.dart';
 
 /// A custom form field for CompromisedAnimals.
 /// Due to it's dynamic nature this widget should only be used inside a grow-able
@@ -12,7 +11,7 @@ dynamicCompromisedAnimalFormField(
         {@required List<CompromisedAnimal> initialList,
         @required String titles,
         @required Function(List<CompromisedAnimal>) onSaved}) =>
-    DynamicFormField<CompromisedAnimal, CompromisedAnimalFormField>(
+    DynamicFormField<CompromisedAnimal>(
         initialList: initialList,
         titles: titles,
         onSaved: onSaved,

--- a/app/lib/ui/views/active/dynamic_form_field/dynamic_contingency_activity_form_field.dart
+++ b/app/lib/ui/views/active/dynamic_form_field/dynamic_contingency_activity_form_field.dart
@@ -1,9 +1,8 @@
 import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
 import 'package:app/ui/views/active/form_field/contingency_activity_form_field.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
-
-import 'dynamic_form_field.dart';
 
 /// A custom form field for ContingencyActivities.
 /// Due to it's dynamic nature this widget should only be used inside a grow-able
@@ -11,12 +10,12 @@ import 'dynamic_form_field.dart';
 dynamicContingencyActivityFormField(
         {@required List<ContingencyActivity> initialList,
         @required Function(List<ContingencyActivity>) onSaved}) =>
-    DynamicFormField<ContingencyActivity, ContingencyActivityFormField>(
+    DynamicFormField<ContingencyActivity>(
         initialList: initialList,
         titles: "Carrier's communication activities",
         onSaved: onSaved,
         blankFieldCreator: () => ContingencyActivity(
-            time: TimeOfDay.now(),
+            time: DateTime.now(),
             personContacted: "",
             methodOfContact: "",
             instructionsGiven: ""),

--- a/app/lib/ui/views/active/dynamic_form_field/dynamic_contingency_plan_event_form_field.dart
+++ b/app/lib/ui/views/active/dynamic_form_field/dynamic_contingency_plan_event_form_field.dart
@@ -1,9 +1,8 @@
 import 'package:app/core/models/contingency_plan_info.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
 import 'package:app/ui/views/active/form_field/contingency_plan_event_form_field.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
-
-import 'dynamic_form_field.dart';
 
 /// A custom form field for ContingencyPlanEvents.
 /// Due to it's dynamic nature this widget should only be used inside a grow-able
@@ -11,7 +10,7 @@ import 'dynamic_form_field.dart';
 dynamicContingencyPlanEventFormField(
         {@required List<ContingencyPlanEvent> initialList,
         @required Function(List<ContingencyPlanEvent>) onSaved}) =>
-    DynamicFormField<ContingencyPlanEvent, ContingencyPlanEventFormField>(
+    DynamicFormField<ContingencyPlanEvent>(
         initialList: initialList,
         titles: "Event Specific Plans",
         onSaved: onSaved,

--- a/app/lib/ui/views/active/dynamic_form_field/dynamic_form_field.dart
+++ b/app/lib/ui/views/active/dynamic_form_field/dynamic_form_field.dart
@@ -1,20 +1,24 @@
 import 'package:flutter/material.dart';
 
-// TODO: #134. This class should offer validation for non-empty lists, if desired
-// Meaning that the validation function should have optional non-empty check
-// if at least one field should exist, and the first item should have no delete button
-/// A custom form field for List<T>. Requires widget builder W.
+// TODO: #134. This class should allow for non-empty lists
+// Meaning that if at least one field should exist, the first item should have no delete button
+/// A custom form field for List<T>.
 /// Due to it's dynamic nature this widget should only be used inside a grow-able
 /// widget, like column, and not inside static widgets like ListTiles.
-class DynamicFormField<T, W extends StatefulWidget> extends StatefulWidget {
+class DynamicFormField<T> extends StatefulWidget {
   final List<T> initialList;
   final String titles;
   final Function(List<T>) onSaved;
   final T Function() blankFieldCreator;
-  final W Function(int, T, Function(int, T), Function(int)) fieldCreator;
 
-  // Use the form key to save all the fields of this form
-  final formKey = GlobalKey<FormState>();
+  // The fieldCreator uses index, initial, onSaved, and onDelete
+  final FormField<T> Function(int, T, Function(int, T), Function(int))
+      fieldCreator;
+  final _formKey = GlobalKey<FormState>();
+
+  void save() => _formKey.currentState.save();
+
+  bool validate() => _formKey.currentState.validate();
 
   DynamicFormField(
       {Key key,
@@ -26,68 +30,69 @@ class DynamicFormField<T, W extends StatefulWidget> extends StatefulWidget {
       : super(key: key);
 
   @override
-  _DynamicFormFieldState<T, W> createState() => _DynamicFormFieldState<T, W>();
+  _DynamicFormFieldState<T> createState() => _DynamicFormFieldState<T>();
 }
 
-class _DynamicFormFieldState<T, W extends StatefulWidget>
-    extends State<DynamicFormField<T, W>> {
+class _DynamicFormFieldState<T> extends State<DynamicFormField<T>> {
   final List<T> _fields = [];
 
-  void _saveAll() {
-    if (widget.formKey.currentState.validate()) {
-      // Calls _saveIndividual for all inner form fields
-      widget.formKey.currentState.save();
-    }
-  }
+  void _saveAll() => widget.save();
 
+  // TODO: #136. Trim empties from the saved list
+  // but keep them in the widget's list to have open spots for new items
   void _saveIndividual(int index, T field) {
     _fields[index] = field;
-    // TODO: Trim empties from the saved list
-    // but keep them in the widget's list to have open spots for new items
     widget.onSaved(_fields);
   }
 
   void _deleteField(int index) => setState(() {
         _saveAll();
-        _fields.removeAt(index);
+        setState(() {
+          _fields.removeAt(index);
+        });
       });
 
   void _addField() => setState(() {
         _saveAll();
-        _fields.add(widget.blankFieldCreator());
+        setState(() {
+          _fields.add(widget.blankFieldCreator());
+        });
       });
 
-  W _createField(int index) {
+  FormField<T> _createField(int index) {
     return widget.fieldCreator(
         index, _fields[index], _saveIndividual, _deleteField);
   }
 
   @override
   void initState() {
-    _fields.addAll(widget.initialList.cast<T>());
+    _fields.addAll(widget.initialList);
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
     return Form(
-        key: widget.formKey,
+        key: widget._formKey,
         child: Column(
           children: [
             _fields.isEmpty
-                ? Text("No ${widget.titles}, add some using the + button")
-                : Container(
-                    child: ListView.builder(
-                        // Make the List take minimum possible space
-                        shrinkWrap: true,
-                        // Intended to be used inside existing scroll-ables
-                        primary: false,
-                        itemCount: _fields.length,
-                        itemBuilder: (_, index) => _createField(index))),
+                ? Text("No ${widget.titles}")
+                : Column(
+                    children: List<FormField<T>>.generate(
+                        _fields.length, (int index) => _createField(index))),
             ListTile(
-              trailing: IconButton(
-                icon: Icon(Icons.add),
+              leading: IconButton(
+                tooltip: "Add ${widget.titles} using this (+) button",
+                icon: Icon(Icons.add_circle),
                 onPressed: _addField,
+              ),
+              trailing: IconButton(
+                tooltip: "Add ${widget.titles} using this (+) button",
+                icon: Icon(Icons.help),
+                onPressed: () => {
+                  // do nothing for help button
+                },
               ),
             ),
           ],

--- a/app/lib/ui/views/active/dynamic_form_field/dynamic_fwr_event_form_field.dart
+++ b/app/lib/ui/views/active/dynamic_form_field/dynamic_fwr_event_form_field.dart
@@ -1,10 +1,9 @@
 import 'package:app/core/models/address.dart';
 import 'package:app/core/models/feed_water_rest_info.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
 import 'package:app/ui/views/active/form_field/fwr_event_form_field.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
-
-import 'dynamic_form_field.dart';
 
 /// A custom form field for FeedWaterRestEvents.
 /// Due to it's dynamic nature this widget should only be used inside a grow-able
@@ -12,7 +11,7 @@ import 'dynamic_form_field.dart';
 dynamicFWREventFormField(
         {@required List<FeedWaterRestEvent> initialList,
         @required Function(List<FeedWaterRestEvent>) onSaved}) =>
-    DynamicFormField<FeedWaterRestEvent, FeedWaterRestEventFormField>(
+    DynamicFormField<FeedWaterRestEvent>(
         initialList: initialList,
         titles: "Feed, Water, and Rest event",
         onSaved: onSaved,

--- a/app/lib/ui/views/active/dynamic_form_field/dynamic_string_form_field.dart
+++ b/app/lib/ui/views/active/dynamic_form_field/dynamic_string_form_field.dart
@@ -1,9 +1,8 @@
 import 'package:app/core/utilities/optional.dart';
+import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
 import 'package:app/ui/views/active/form_field/string_form_field.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:uuid/uuid.dart';
-
-import 'dynamic_form_field.dart';
 
 /// A custom form field for List<String>.
 /// Due to it's dynamic nature this widget should only be used inside a grow-able
@@ -12,7 +11,7 @@ dynamicStringFormField(
         {@required List<String> initialList,
         @required String titles,
         @required Function(List<String>) onSaved}) =>
-    DynamicFormField<String, StringFormField>(
+    DynamicFormField<String>(
         initialList: initialList,
         titles: titles,
         onSaved: onSaved,

--- a/app/lib/ui/views/active/form_field/acknowledgement_info_form_field.dart
+++ b/app/lib/ui/views/active/form_field/acknowledgement_info_form_field.dart
@@ -5,9 +5,11 @@ class AcknowledgementInfoFormField extends StatefulWidget {
   final Function(AcknowledgementInfo info) onSaved;
   final AcknowledgementInfo initialInfo;
   final String title = "Acknowledgements";
+  final _formKey = GlobalKey<FormState>();
 
-  // Use the form key to save all the fields of this form
-  final formKey = GlobalKey<FormState>();
+  void save() => _formKey.currentState.save();
+
+  bool validate() => _formKey.currentState.validate();
 
   AcknowledgementInfoFormField(
       {Key key, @required this.initialInfo, @required this.onSaved})
@@ -21,14 +23,16 @@ class AcknowledgementInfoFormField extends StatefulWidget {
 class _AcknowledgementInfoFormFieldState
     extends State<AcknowledgementInfoFormField> {
 // TODO: Resolve how to edit ack info
-  void _saveAll() {
-    widget.onSaved(widget.initialInfo);
+  void _saveAll() => widget.onSaved(widget.initialInfo);
+
+  void _validateAndSaveAll() {
+    if (widget.validate()) _saveAll();
   }
 
   @override
   Widget build(BuildContext context) {
     return Form(
-      key: widget.formKey,
+      key: widget._formKey,
       child: Column(children: [
         ListTile(
           title: Text("Shipper acknowledgement"),
@@ -42,7 +46,7 @@ class _AcknowledgementInfoFormFieldState
           title: Text("Consignee acknowledgement"),
           subtitle: Text("TODO"),
         ),
-        RaisedButton(child: Text("Save"), onPressed: _saveAll)
+        RaisedButton(child: Text("Save"), onPressed: _validateAndSaveAll)
       ]),
     );
   }

--- a/app/lib/ui/views/active/form_field/address_form_field.dart
+++ b/app/lib/ui/views/active/form_field/address_form_field.dart
@@ -3,14 +3,11 @@ import 'package:app/core/utilities/optional.dart';
 import 'package:app/ui/views/active/form_field/string_form_field.dart';
 import 'package:flutter/material.dart';
 
-/// A custom form field for addresses
+/// A custom form field for Addresses
 /// Intended to be used inside a GroupFormField
 class AddressFormField extends StatefulWidget {
   final Address initialAddr;
   final Function(Address) onSaved;
-
-  // Use the form key to save all the fields of this form
-  final formKey = GlobalKey<FormState>();
 
   AddressFormField(
       {Key key, @required this.initialAddr, @required this.onSaved})
@@ -39,61 +36,56 @@ class _AddressFormFieldState extends State<AddressFormField> {
     super.initState();
   }
 
-  void _saveAll() {
-    widget.onSaved(Address(
-        streetAddress: _street,
-        city: _city,
-        provinceOrState: _provinceOrState,
-        country: _country,
-        postalCode: _postalCode));
-  }
+  void _saveAll() => widget.onSaved(Address(
+      streetAddress: _street,
+      city: _city,
+      provinceOrState: _provinceOrState,
+      country: _country,
+      postalCode: _postalCode));
 
   @override
   Widget build(BuildContext context) {
-    return Form(
-      key: widget.formKey,
-      child: Column(children: [
-        StringFormField(
-            initial: _street,
-            title: "Street",
-            onSaved: (String changed) {
-              _street = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        StringFormField(
-            initial: _city,
-            title: "City",
-            onSaved: (String changed) {
-              _city = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        StringFormField(
-            initial: _provinceOrState,
-            title: "Province or State",
-            onSaved: (String changed) {
-              _provinceOrState = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        StringFormField(
-            initial: _country,
-            title: "Country",
-            onSaved: (String changed) {
-              _country = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        StringFormField(
-            initial: _postalCode,
-            title: "Postal Code",
-            onSaved: (String changed) {
-              _postalCode = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-      ]),
-    );
+    return Column(children: [
+      StringFormField(
+          initial: _street,
+          title: "Street",
+          onSaved: (String changed) {
+            _street = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      StringFormField(
+          initial: _city,
+          title: "City",
+          onSaved: (String changed) {
+            _city = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      StringFormField(
+          initial: _provinceOrState,
+          title: "Province or State",
+          onSaved: (String changed) {
+            _provinceOrState = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      StringFormField(
+          initial: _country,
+          title: "Country",
+          onSaved: (String changed) {
+            _country = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      StringFormField(
+          initial: _postalCode,
+          title: "Postal Code",
+          onSaved: (String changed) {
+            _postalCode = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+    ]);
   }
 }

--- a/app/lib/ui/views/active/form_field/animal_group_form_field.dart
+++ b/app/lib/ui/views/active/form_field/animal_group_form_field.dart
@@ -6,19 +6,41 @@ import 'package:app/ui/views/active/form_field/int_form_field.dart';
 import 'package:app/ui/views/active/form_field/string_form_field.dart';
 import 'package:flutter/material.dart';
 
-import 'compromised_animal_form_field.dart';
+// TODO: Extract validators into their own service
+String emptyFieldValidation(String value) {
+  if (value.isEmpty) {
+    return "* Required";
+  } else
+    return null;
+}
 
-class AnimalGroupFormField extends StatefulWidget {
-  final Function(AnimalGroup info) onSaved;
-  final Function() onDelete;
-  final AnimalGroup initialInfo;
-
-  // Use the form key to save all the fields of this form
-  final formKey = GlobalKey<FormState>();
-
+/// A custom form field with onSaved and onDelete callback
+class AnimalGroupFormField extends FormField<AnimalGroup> {
   AnimalGroupFormField(
       {Key key,
-      @required this.initialInfo,
+      @required AnimalGroup initial,
+      @required FormFieldSetter<AnimalGroup> onSaved,
+      @required Function() onDelete})
+      : super(
+            key: key,
+            initialValue: initial,
+            builder: (FormFieldState<AnimalGroup> state) {
+              return _AnimalGroupFormFieldInner(
+                initial: state.value,
+                onSaved: onSaved,
+                onDelete: onDelete,
+              );
+            });
+}
+
+class _AnimalGroupFormFieldInner extends StatefulWidget {
+  final Function(AnimalGroup info) onSaved;
+  final Function() onDelete;
+  final AnimalGroup initial;
+
+  _AnimalGroupFormFieldInner(
+      {Key key,
+      @required this.initial,
       @required this.onSaved,
       @required this.onDelete})
       : super(key: key);
@@ -27,7 +49,7 @@ class AnimalGroupFormField extends StatefulWidget {
   _AnimalGroupFormFieldState createState() => _AnimalGroupFormFieldState();
 }
 
-class _AnimalGroupFormFieldState extends State<AnimalGroupFormField> {
+class _AnimalGroupFormFieldState extends State<_AnimalGroupFormFieldInner> {
   String _species;
   int _groupAge;
   int _approximateWeight;
@@ -37,22 +59,20 @@ class _AnimalGroupFormFieldState extends State<AnimalGroupFormField> {
   List<CompromisedAnimal> _compromisedAnimals;
   List<CompromisedAnimal> _specialNeedsAnimals;
 
-  DynamicFormField<CompromisedAnimal, CompromisedAnimalFormField>
-      _compromisedAnimalsFormField;
-  DynamicFormField<CompromisedAnimal, CompromisedAnimalFormField>
-      _specialNeedsAnimalsFormField;
+  DynamicFormField<CompromisedAnimal> _compromisedAnimalsFormField;
+  DynamicFormField<CompromisedAnimal> _specialNeedsAnimalsFormField;
 
   @override
   void initState() {
-    _species = widget.initialInfo.species;
-    _groupAge = widget.initialInfo.groupAge;
-    _approximateWeight = widget.initialInfo.approximateWeight;
-    _animalPurpose = widget.initialInfo.animalPurpose;
-    _numberAnimals = widget.initialInfo.numberAnimals;
+    _species = widget.initial.species;
+    _groupAge = widget.initial.groupAge;
+    _approximateWeight = widget.initial.approximateWeight;
+    _animalPurpose = widget.initial.animalPurpose;
+    _numberAnimals = widget.initial.numberAnimals;
     _animalsFitForTransport =
-        widget.initialInfo.animalsFitForTransport ? "Yes" : "No";
-    _compromisedAnimals = widget.initialInfo.compromisedAnimals;
-    _specialNeedsAnimals = widget.initialInfo.specialNeedsAnimals;
+        widget.initial.animalsFitForTransport ? "Yes" : "No";
+    _compromisedAnimals = widget.initial.compromisedAnimals;
+    _specialNeedsAnimals = widget.initial.specialNeedsAnimals;
     _compromisedAnimalsFormField = dynamicCompromisedAnimalFormField(
         initialList: _compromisedAnimals,
         titles: "Compromised animal",
@@ -80,74 +100,91 @@ class _AnimalGroupFormFieldState extends State<AnimalGroupFormField> {
       compromisedAnimals: _compromisedAnimals,
       specialNeedsAnimals: _specialNeedsAnimals));
 
+  // As the forms are nested, they need to be told to validate
+  // Only one call to validate them is needed as this form's fields are validated together
+  void _validateNestedForms() {
+    _compromisedAnimalsFormField.validate();
+    _specialNeedsAnimalsFormField.validate();
+  }
+
+  // As the forms are nested, they need to be told to save
+  // Only one call to saved them is needed as this form's fields are saved together
+  void _saveNestedForms() {
+    _compromisedAnimalsFormField.save();
+    _specialNeedsAnimalsFormField.save();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Form(
-      key: widget.formKey,
-      child: Column(children: [
-        ListTile(
-          title: Text("Animal Group"),
-          trailing: IconButton(
-            icon: Icon(Icons.delete),
-            onPressed: widget.onDelete,
-          ),
+    return Column(children: [
+      ListTile(
+        title: Text("Animal Group"),
+        trailing: IconButton(
+          icon: Icon(Icons.delete),
+          onPressed: widget.onDelete,
         ),
-        StringFormField(
-            initial: _species,
-            title: "Species",
-            onSaved: (String changed) {
-              _species = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        IntFormField(
-            initial: _groupAge,
-            title: "Approximate group age",
-            onSaved: (int changed) {
-              _groupAge = changed;
-              _saveAll();
-            }),
-        IntFormField(
-            initial: _approximateWeight,
-            title: "Approximate group weight",
-            onSaved: (int changed) {
-              _approximateWeight = changed;
-              _saveAll();
-            }),
-        StringFormField(
-            initial: _animalPurpose,
-            title: "Purpose of the animals",
-            onSaved: (String changed) {
-              _animalPurpose = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        IntFormField(
-            initial: _numberAnimals,
-            title: "Number of animals on the transport",
-            onSaved: (int changed) {
-              _numberAnimals = changed;
-              _saveAll();
-            }),
-        ListTile(
-            visualDensity: VisualDensity(horizontal: 0, vertical: -2),
-            title: Text("Are all animals fit for transport?"),
-            subtitle: DropdownButtonFormField(
-              value: _animalsFitForTransport,
-              items: ["Yes", "No"]
-                  .map((label) => DropdownMenuItem(
-                        child: Text(label),
-                        value: label,
-                      ))
-                  .toList(),
-              onChanged: (String changed) => setState(() {
-                _animalsFitForTransport = changed;
-                _saveAll();
-              }),
-            )),
-        _compromisedAnimalsFormField,
-        _specialNeedsAnimalsFormField,
-      ]),
-    );
+      ),
+      StringFormField(
+          initial: _species,
+          title: "Species",
+          validator: (String field) {
+            _validateNestedForms();
+            return emptyFieldValidation(field);
+          },
+          onSaved: (String changed) {
+            _species = changed;
+            _saveNestedForms();
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      IntFormField(
+          initial: _groupAge,
+          title: "Approximate group age",
+          onSaved: (int changed) {
+            _groupAge = changed;
+            _saveAll();
+          }),
+      IntFormField(
+          initial: _approximateWeight,
+          title: "Approximate group weight",
+          onSaved: (int changed) {
+            _approximateWeight = changed;
+            _saveAll();
+          }),
+      StringFormField(
+          initial: _animalPurpose,
+          title: "Purpose of the animals",
+          onSaved: (String changed) {
+            _animalPurpose = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      IntFormField(
+          initial: _numberAnimals,
+          title: "Number of animals on the transport",
+          onSaved: (int changed) {
+            _numberAnimals = changed;
+            _saveAll();
+          }),
+      ListTile(
+          title: DropdownButtonFormField(
+        decoration: InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: "Are all animals fit for transport?"),
+        value: _animalsFitForTransport,
+        items: ["Yes", "No"]
+            .map((label) => DropdownMenuItem(
+                  child: Text(label),
+                  value: label,
+                ))
+            .toList(),
+        onChanged: (String changed) => setState(() {
+          _animalsFitForTransport = changed;
+          _saveAll();
+        }),
+      )),
+      _compromisedAnimalsFormField,
+      _specialNeedsAnimalsFormField,
+    ]);
   }
 }

--- a/app/lib/ui/views/active/form_field/compromised_animal_form_field.dart
+++ b/app/lib/ui/views/active/form_field/compromised_animal_form_field.dart
@@ -4,13 +4,34 @@ import 'package:app/ui/views/active/form_field/string_form_field.dart';
 import 'package:flutter/material.dart';
 
 /// A custom form field with onSaved and onDelete callback
-class CompromisedAnimalFormField extends StatefulWidget {
+class CompromisedAnimalFormField extends FormField<CompromisedAnimal> {
+  CompromisedAnimalFormField(
+      {Key key,
+      @required CompromisedAnimal initial,
+      @required String title,
+      @required Function(CompromisedAnimal) onSaved,
+      @required Function() onDelete})
+      : super(
+            key: key,
+            onSaved: onSaved,
+            initialValue: initial,
+            builder: (FormFieldState<CompromisedAnimal> state) {
+              return _CompromisedAnimalFormFieldInner(
+                title: title,
+                initial: state.value,
+                onSaved: onSaved,
+                onDelete: onDelete,
+              );
+            });
+}
+
+class _CompromisedAnimalFormFieldInner extends StatefulWidget {
   final CompromisedAnimal initial;
   final String title;
   final Function(CompromisedAnimal) onSaved;
   final Function() onDelete;
 
-  CompromisedAnimalFormField(
+  _CompromisedAnimalFormFieldInner(
       {Key key,
       @required this.initial,
       @required this.title,
@@ -24,7 +45,7 @@ class CompromisedAnimalFormField extends StatefulWidget {
 }
 
 class _CompromisedAnimalFormFieldState
-    extends State<CompromisedAnimalFormField> {
+    extends State<_CompromisedAnimalFormFieldInner> {
   String _animalDescription;
   String _measuresTakenToCareForAnimal;
 

--- a/app/lib/ui/views/active/form_field/contingency_activity_form_field.dart
+++ b/app/lib/ui/views/active/form_field/contingency_activity_form_field.dart
@@ -5,12 +5,31 @@ import 'package:app/ui/widgets/utility/date_time_picker.dart';
 import 'package:flutter/material.dart';
 
 /// A custom form field with onSaved and onDelete callback
-class ContingencyActivityFormField extends StatefulWidget {
+class ContingencyActivityFormField extends FormField<ContingencyActivity> {
+  ContingencyActivityFormField(
+      {Key key,
+      @required ContingencyActivity initial,
+      @required FormFieldSetter<ContingencyActivity> onSaved,
+      @required Function() onDelete})
+      : super(
+            key: key,
+            onSaved: onSaved,
+            initialValue: initial,
+            builder: (FormFieldState<ContingencyActivity> state) {
+              return _ContingencyActivityFormFieldInner(
+                initial: state.value,
+                onSaved: onSaved,
+                onDelete: onDelete,
+              );
+            });
+}
+
+class _ContingencyActivityFormFieldInner extends StatefulWidget {
   final ContingencyActivity initial;
   final Function(ContingencyActivity) onSaved;
   final Function() onDelete;
 
-  ContingencyActivityFormField(
+  _ContingencyActivityFormFieldInner(
       {Key key,
       @required this.initial,
       @required this.onSaved,
@@ -23,8 +42,8 @@ class ContingencyActivityFormField extends StatefulWidget {
 }
 
 class _ContingencyActivityFormFieldState
-    extends State<ContingencyActivityFormField> {
-  TimeOfDay _time;
+    extends State<_ContingencyActivityFormFieldInner> {
+  DateTime _time;
   String _personContacted;
   String _methodOfContact;
   String _instructionsGiven;
@@ -60,7 +79,7 @@ class _ContingencyActivityFormFieldState
           subtitle: timePicker(
               initialTime: _time,
               onSaved: (String changed) {
-                _time = TimeOfDay.fromDateTime(DateTime.parse(changed));
+                _time = DateTime.parse(changed);
                 _saveAll();
               }),
         ),

--- a/app/lib/ui/views/active/form_field/fwr_event_form_field.dart
+++ b/app/lib/ui/views/active/form_field/fwr_event_form_field.dart
@@ -1,17 +1,35 @@
 import 'package:app/core/models/address.dart';
 import 'package:app/core/models/feed_water_rest_info.dart';
+import 'package:app/ui/views/active/form_field/address_form_field.dart';
 import 'package:app/ui/widgets/utility/date_time_picker.dart';
 import 'package:flutter/material.dart';
 
-import 'address_form_field.dart';
-
 /// A custom form field with onSaved and onDelete callback
-class FeedWaterRestEventFormField extends StatefulWidget {
+class FeedWaterRestEventFormField extends FormField<FeedWaterRestEvent> {
+  FeedWaterRestEventFormField(
+      {Key key,
+      @required FeedWaterRestEvent initial,
+      @required FormFieldSetter<FeedWaterRestEvent> onSaved,
+      @required Function() onDelete})
+      : super(
+            key: key,
+            onSaved: onSaved,
+            initialValue: initial,
+            builder: (FormFieldState<FeedWaterRestEvent> state) {
+              return _FeedWaterRestEventFormFieldInner(
+                initial: state.value,
+                onSaved: onSaved,
+                onDelete: onDelete,
+              );
+            });
+}
+
+class _FeedWaterRestEventFormFieldInner extends StatefulWidget {
   final FeedWaterRestEvent initial;
-  final Function(FeedWaterRestEvent) onSaved;
+  final FormFieldSetter<FeedWaterRestEvent> onSaved;
   final Function() onDelete;
 
-  FeedWaterRestEventFormField(
+  _FeedWaterRestEventFormFieldInner(
       {Key key,
       @required this.initial,
       @required this.onSaved,
@@ -24,7 +42,7 @@ class FeedWaterRestEventFormField extends StatefulWidget {
 }
 
 class _FeedWaterRestEventFormFieldState
-    extends State<FeedWaterRestEventFormField> {
+    extends State<_FeedWaterRestEventFormFieldInner> {
   String _animalsWereUnloaded;
   DateTime _fwrTime;
   Address _lastFwrLocation;
@@ -66,9 +84,9 @@ class _FeedWaterRestEventFormFieldState
           ),
         ),
         ListTile(
-          visualDensity: VisualDensity(horizontal: 0, vertical: -2),
-          title: Text("Animals unloaded?"),
-          subtitle: DropdownButtonFormField(
+          title: DropdownButtonFormField(
+            decoration: InputDecoration(
+                border: OutlineInputBorder(), labelText: "Animals unloaded?"),
             value: _animalsWereUnloaded,
             items: ["Yes", "No"]
                 .map((label) => DropdownMenuItem(
@@ -92,21 +110,22 @@ class _FeedWaterRestEventFormFieldState
                 })),
         ListTile(title: Text("Address"), subtitle: _lastFwrAddressFormField),
         ListTile(
-            visualDensity: VisualDensity(horizontal: 0, vertical: -2),
-            title: Text("Feed, water, and rest provided onboard?"),
-            subtitle: DropdownButtonFormField(
-              value: _fwrProvidedOnboard,
-              items: ["Yes", "No"]
-                  .map((label) => DropdownMenuItem(
-                        child: Text(label),
-                        value: label,
-                      ))
-                  .toList(),
-              onChanged: (String changed) => setState(() {
-                _fwrProvidedOnboard = changed;
-                _saveAll();
-              }),
-            )),
+            title: DropdownButtonFormField(
+          decoration: InputDecoration(
+              border: OutlineInputBorder(),
+              labelText: "Feed, water, and rest provided onboard?"),
+          value: _fwrProvidedOnboard,
+          items: ["Yes", "No"]
+              .map((label) => DropdownMenuItem(
+                    child: Text(label),
+                    value: label,
+                  ))
+              .toList(),
+          onChanged: (String changed) => setState(() {
+            _fwrProvidedOnboard = changed;
+            _saveAll();
+          }),
+        )),
       ],
     );
   }

--- a/app/lib/ui/views/active/form_field/fwr_info_form_field.dart
+++ b/app/lib/ui/views/active/form_field/fwr_info_form_field.dart
@@ -2,19 +2,21 @@ import 'package:app/core/models/address.dart';
 import 'package:app/core/models/feed_water_rest_info.dart';
 import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
 import 'package:app/ui/views/active/dynamic_form_field/dynamic_fwr_event_form_field.dart';
+import 'package:app/ui/views/active/form_field/address_form_field.dart';
 import 'package:app/ui/widgets/utility/date_time_picker.dart';
 import 'package:flutter/material.dart';
-
-import 'address_form_field.dart';
-import 'fwr_event_form_field.dart';
 
 class FeedWaterRestInfoFormField extends StatefulWidget {
   final Function(FeedWaterRestInfo info) onSaved;
   final FeedWaterRestInfo initialInfo;
   final String title = "Feed, Water, and Rest Information";
+  final _innerFormKey = GlobalKey<FormState>();
 
-  // Use the form key to save all the fields of this form
-  final formKey = GlobalKey<FormState>();
+  void save() => _innerFormKey.currentState.save();
+
+  // This function does not change the state of the widget
+  // Must call validate within widget for error text to appear
+  bool validate() => _innerFormKey.currentState.validate();
 
   FeedWaterRestInfoFormField(
       {Key key, @required this.initialInfo, @required this.onSaved})
@@ -32,8 +34,7 @@ class _FeedWaterRestInfoFormFieldState
   List<FeedWaterRestEvent> _fwrEvents;
 
   AddressFormField _lastFwrAddressFormField;
-  DynamicFormField<FeedWaterRestEvent, FeedWaterRestEventFormField>
-      _fwrEventFormField;
+  DynamicFormField<FeedWaterRestEvent> _fwrEventFormField;
 
   @override
   void initState() {
@@ -44,6 +45,7 @@ class _FeedWaterRestInfoFormFieldState
         initialAddr: _lastFwrLocation,
         onSaved: (Address changed) {
           _lastFwrLocation = changed;
+          _saveNestedForms();
           _saveAll();
         });
     _fwrEventFormField = dynamicFWREventFormField(
@@ -55,15 +57,26 @@ class _FeedWaterRestInfoFormFieldState
     super.initState();
   }
 
+  // As the forms are nested, they need to be told to save
+  // Only one call to saved them is needed as this form's fields are saved together
+  void _saveNestedForms() => _fwrEventFormField.save();
+
   void _saveAll() => widget.onSaved(FeedWaterRestInfo(
       lastFwrDate: _lastFwrDate,
       lastFwrLocation: _lastFwrLocation,
       fwrEvents: _fwrEvents));
 
+  void _validateAndSaveAll() {
+    // Do not short-circuit the validation calls using &&
+    final isFormValid = widget._innerFormKey.currentState.validate();
+    final isInnerFormValid = _fwrEventFormField.validate();
+    if (isFormValid && isInnerFormValid) widget.save();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Form(
-      key: widget.formKey,
+      key: widget._innerFormKey,
       child: Column(children: [
         ListTile(
             title: Text(
@@ -79,7 +92,7 @@ class _FeedWaterRestInfoFormFieldState
             subtitle: _lastFwrAddressFormField),
         ListTile(title: Text("If FWR was provided during transport")),
         _fwrEventFormField,
-        RaisedButton(child: Text("Save"), onPressed: _saveAll)
+        RaisedButton(child: Text("Save"), onPressed: _validateAndSaveAll)
       ]),
     );
   }

--- a/app/lib/ui/views/active/form_field/int_form_field.dart
+++ b/app/lib/ui/views/active/form_field/int_form_field.dart
@@ -1,49 +1,58 @@
 import 'package:flutter/material.dart';
 
-/// A custom form field with onSaved and onDelete callback
-class IntFormField extends StatefulWidget {
-  final int initial;
-  final String title;
-  final Function(int) onSaved;
-
-  IntFormField(
-      {Key key,
-      @required this.initial,
-      @required this.title,
-      @required this.onSaved})
-      : super(key: key);
-
-  @override
-  _IntFormFieldState createState() => _IntFormFieldState();
+// TODO: Extract validators into their own service
+String emptyFieldValidation(int value) {
+  if (value == null || value == 0) {
+    return "* Required";
+  } else {
+    return null;
+  }
 }
 
-class _IntFormFieldState extends State<IntFormField> {
-  TextEditingController controller;
+/// A custom form field with onSaved and onDelete callback
+class IntFormField extends FormField<int> {
+  IntFormField(
+      {Key key,
+      @required int initial,
+      @required String title,
+      @required FormFieldSetter<int> onSaved,
+      FormFieldValidator<int> validator = emptyFieldValidation})
+      : super(
+            key: key,
+            initialValue: initial,
+            builder: (FormFieldState<int> state) {
+              return _IntFormFieldState(
+                state: state,
+                title: title,
+                onSaved: onSaved,
+                validator: validator,
+              );
+            });
+}
 
-  @override
-  void initState() {
-    controller = TextEditingController(text: widget.initial.toString());
-    super.initState();
-  }
+class _IntFormFieldState extends StatelessWidget {
+  final FormFieldState<int> state;
+  final String title;
+  final FormFieldSetter<int> onSaved;
+  final FormFieldValidator<int> validator;
 
-  @override
-  void dispose() {
-    controller.dispose();
-    super.dispose();
-  }
+  _IntFormFieldState({
+    @required this.state,
+    @required this.title,
+    @required this.onSaved,
+    @required this.validator,
+  });
 
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      title: Text(widget.title),
-      subtitle: TextFormField(
+      title: TextFormField(
+        initialValue: state.value.toString(),
+        validator: (String field) => validator(int.tryParse(field)),
+        decoration:
+            InputDecoration(border: OutlineInputBorder(), labelText: title),
         keyboardType: TextInputType.number,
-        controller: controller,
-        // TODO: This is intensive to do, and should be refactored sometime
-        // This is the same as onSaved, so we can avoid needing an
-        // explicit save button in dynamic forms
-        onChanged: (String changed) => widget.onSaved(int.parse(changed)),
-        onSaved: (String changed) => widget.onSaved(int.parse(changed)),
+        onSaved: (String changed) => onSaved(int.parse(changed)),
       ),
     );
   }

--- a/app/lib/ui/views/active/form_field/receiver_info_form_field.dart
+++ b/app/lib/ui/views/active/form_field/receiver_info_form_field.dart
@@ -1,17 +1,18 @@
 import 'package:app/core/models/address.dart';
 import 'package:app/core/models/receiver_info.dart';
 import 'package:app/core/utilities/optional.dart';
+import 'package:app/ui/views/active/form_field/address_form_field.dart';
 import 'package:app/ui/views/active/form_field/string_form_field.dart';
 import 'package:flutter/material.dart';
 
-import 'address_form_field.dart';
+// TODO: Extract validators into their own service
+String canBeEmptyFieldValidation(String value) {
+  return null;
+}
 
 class ReceiverInfoFormField extends StatefulWidget {
   final Function(ReceiverInfo info) onSaved;
   final ReceiverInfo initialInfo;
-
-  // Use the form key to save all the fields of this form
-  final formKey = GlobalKey<FormState>();
 
   ReceiverInfoFormField(
       {Key key, @required this.initialInfo, @required this.onSaved})
@@ -61,64 +62,62 @@ class _ReceiverInfoFormFieldState extends State<ReceiverInfoFormField> {
 
   @override
   Widget build(BuildContext context) {
-    return Form(
-      key: widget.formKey,
-      child: Column(children: [
-        StringFormField(
-            initial: _receiverCompanyName,
-            title: "Receiving company name",
-            onSaved: (String changed) {
-              _receiverCompanyName = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        StringFormField(
-            initial: _receiverName,
-            title: "Representative name",
-            onSaved: (String changed) {
-              _receiverName = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        StringFormField(
-            initial: _accountId.isPresent() ? _accountId.get() : "",
-            title:
-                "Account identification number of the consignee in the database of the responsible administrator (Optional)",
-            onSaved: (String changed) {
-              _accountId =
-                  changed == "" ? Optional.empty() : Optional.of(changed);
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        StringFormField(
-            initial: _destinationLocationId,
-            title: "Destination and Premises Identification number (PID)",
-            onSaved: (String changed) {
-              _destinationLocationId = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        StringFormField(
-            initial: _destinationLocationName,
-            title: "Destination and Premises name",
-            onSaved: (String changed) {
-              _destinationLocationName = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-        ListTile(
-          title: Text("Destination and Premises address"),
-          subtitle: _destinationAddressFormField,
-        ),
-        StringFormField(
-            initial: _receiverContactInfo,
-            title: "Receiver’s Contact number in case of emergency",
-            onSaved: (String changed) {
-              _receiverContactInfo = changed;
-              _saveAll();
-            },
-            onDelete: Optional.empty()),
-      ]),
-    );
+    return Column(children: [
+      StringFormField(
+          initial: _receiverCompanyName,
+          title: "Receiving company name",
+          onSaved: (String changed) {
+            _receiverCompanyName = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      StringFormField(
+          initial: _receiverName,
+          title: "Representative name",
+          onSaved: (String changed) {
+            _receiverName = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      StringFormField(
+          initial: _accountId.isPresent() ? _accountId.get() : "",
+          validator: canBeEmptyFieldValidation,
+          title:
+              "Account identification number of the consignee in the database of the responsible administrator (Optional)",
+          onSaved: (String changed) {
+            _accountId =
+                changed == "" ? Optional.empty() : Optional.of(changed);
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      StringFormField(
+          initial: _destinationLocationId,
+          title: "Destination and Premises Identification number (PID)",
+          onSaved: (String changed) {
+            _destinationLocationId = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      StringFormField(
+          initial: _destinationLocationName,
+          title: "Destination and Premises name",
+          onSaved: (String changed) {
+            _destinationLocationName = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+      ListTile(
+        title: Text("Destination and Premises address"),
+        subtitle: _destinationAddressFormField,
+      ),
+      StringFormField(
+          initial: _receiverContactInfo,
+          title: "Receiver’s Contact number in case of emergency",
+          onSaved: (String changed) {
+            _receiverContactInfo = changed;
+            _saveAll();
+          },
+          onDelete: Optional.empty()),
+    ]);
   }
 }

--- a/app/lib/ui/views/active/form_field/shipper_info_form_field.dart
+++ b/app/lib/ui/views/active/form_field/shipper_info_form_field.dart
@@ -1,18 +1,19 @@
 import 'package:app/core/models/address.dart';
 import 'package:app/core/models/shipper_info.dart';
 import 'package:app/core/utilities/optional.dart';
+import 'package:app/ui/views/active/form_field/address_form_field.dart';
 import 'package:app/ui/views/active/form_field/string_form_field.dart';
 import 'package:flutter/material.dart';
-
-import 'address_form_field.dart';
 
 class ShipperInfoFormField extends StatefulWidget {
   final Function(ShipperInfo info) onSaved;
   final ShipperInfo initialInfo;
   final String title = "Shipper's Information";
+  final _formKey = GlobalKey<FormState>();
 
-  // Use the form key to save all the fields of this form
-  final formKey = GlobalKey<FormState>();
+  void save() => _formKey.currentState.save();
+
+  bool validate() => _formKey.currentState.validate();
 
   ShipperInfoFormField(
       {Key key, @required this.initialInfo, @required this.onSaved})
@@ -49,20 +50,22 @@ class _ShipperInfoFormFieldState extends State<ShipperInfoFormField> {
     super.initState();
   }
 
-  void _saveAll() {
-    widget.onSaved(ShipperInfo(
-        shipperName: _name,
-        shipperIsAnimalOwner: _isAnimalOwner == "Yes" ? true : false,
-        departureLocationId: _departureId,
-        departureLocationName: _departureLocationName,
-        departureAddress: _departureAddress,
-        shipperContactInfo: _contactInfo));
+  void _saveAll() => widget.onSaved(ShipperInfo(
+      shipperName: _name,
+      shipperIsAnimalOwner: _isAnimalOwner == "Yes" ? true : false,
+      departureLocationId: _departureId,
+      departureLocationName: _departureLocationName,
+      departureAddress: _departureAddress,
+      shipperContactInfo: _contactInfo));
+
+  void _validateAndSaveAll() {
+    if (widget.validate()) widget.save();
   }
 
   @override
   Widget build(BuildContext context) {
     return Form(
-      key: widget.formKey,
+      key: widget._formKey,
       child: Column(children: [
         StringFormField(
             initial: _name,
@@ -73,22 +76,23 @@ class _ShipperInfoFormFieldState extends State<ShipperInfoFormField> {
             },
             onDelete: Optional.empty()),
         ListTile(
-            visualDensity: VisualDensity(horizontal: 0, vertical: -2),
-            title: Text(
-                "The shipper is the owner of the animals loaded in the vehicle?"),
-            subtitle: DropdownButtonFormField(
-              value: _isAnimalOwner,
-              items: ["Yes", "No"]
-                  .map((label) => DropdownMenuItem(
-                        child: Text(label),
-                        value: label,
-                      ))
-                  .toList(),
-              onChanged: (String changed) => setState(() {
-                _isAnimalOwner = changed;
-                _saveAll();
-              }),
-            )),
+            title: DropdownButtonFormField(
+          decoration: InputDecoration(
+              border: OutlineInputBorder(),
+              labelText:
+                  "The shipper is the owner of the animals loaded in the vehicle?"),
+          value: _isAnimalOwner,
+          items: ["Yes", "No"]
+              .map((label) => DropdownMenuItem(
+                    child: Text(label),
+                    value: label,
+                  ))
+              .toList(),
+          onChanged: (String changed) => setState(() {
+            _isAnimalOwner = changed;
+            _saveAll();
+          }),
+        )),
         StringFormField(
             initial: _departureId,
             title: "Departure Premises Identification number (PID)",
@@ -116,7 +120,7 @@ class _ShipperInfoFormFieldState extends State<ShipperInfoFormField> {
               _saveAll();
             },
             onDelete: Optional.empty()),
-        RaisedButton(child: Text("Save"), onPressed: _saveAll)
+        RaisedButton(child: Text("Save"), onPressed: _validateAndSaveAll)
       ]),
     );
   }

--- a/app/lib/ui/widgets/utility/date_time_picker.dart
+++ b/app/lib/ui/widgets/utility/date_time_picker.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 DateTimePicker dateTimePicker(
         {@required DateTime initialDate, @required Function(String) onSaved}) =>
     DateTimePicker(
+      decoration: InputDecoration(border: OutlineInputBorder()),
       type: DateTimePickerType.dateTimeSeparate,
       initialValue: initialDate.toString(),
       firstDate: DateTime(2000),
@@ -13,16 +14,11 @@ DateTimePicker dateTimePicker(
     );
 
 DateTimePicker timePicker(
-        {@required TimeOfDay initialTime,
-        @required Function(String) onSaved}) =>
+        {@required DateTime initialTime, @required Function(String) onSaved}) =>
     DateTimePicker(
+      decoration: InputDecoration(border: OutlineInputBorder()),
       type: DateTimePickerType.time,
-      initialValue: convertTimeOfDayToString(initialTime),
-      onSaved: onSaved,
-      onChanged: onSaved,
+      initialValue: DateFormat('HH:mm').format(initialTime),
+      onSaved: (String changed) => onSaved("1970-01-01 $changed"),
+      onChanged: (String changed) => onSaved("1970-01-01 $changed"),
     );
-
-/// The TimeOfDay toString() is not like DateTime toString()
-/// This function converts it to the expected string of HH:mm
-String convertTimeOfDayToString(TimeOfDay initialTime) =>
-    initialTime.toString().substring(10, 15);

--- a/app/test/ui/views/active/atr_editing_screen_test.dart
+++ b/app/test/ui/views/active/atr_editing_screen_test.dart
@@ -1,6 +1,5 @@
 import 'package:app/core/models/animal_transport_record.dart';
 import 'package:app/core/services/dialog_service.dart';
-import 'package:app/core/services/nav_service.dart';
 import 'package:app/core/view_models/active_screen_view_model.dart';
 import 'package:app/test/test_data.dart';
 import 'package:app/ui/views/active/atr_editing_screen.dart';
@@ -16,8 +15,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mockito/mockito.dart';
 
-class MockNavigationService extends Mock implements NavigationService {}
-
 class MockDialogService extends Mock implements DialogService {}
 
 class MockActiveScreenViewModel extends Mock implements ActiveScreenViewModel {}
@@ -26,6 +23,7 @@ final testLocator = GetIt.instance;
 
 void main() {
   final mockActiveScreenViewModel = MockActiveScreenViewModel();
+  final mockDialogService = MockDialogService();
 
   Future<void> pumpATREditingScreen(
           WidgetTester tester, AnimalTransportRecord initialATR) async =>
@@ -35,6 +33,7 @@ void main() {
     setUpAll(() async {
       testLocator.registerLazySingleton<ActiveScreenViewModel>(
           () => mockActiveScreenViewModel);
+      testLocator.registerLazySingleton<DialogService>(() => mockDialogService);
     });
 
     testWidgets('has shipping info form field', (WidgetTester tester) async {
@@ -144,7 +143,7 @@ void main() {
           fwrInfo: testFwrInfo(lastFwrLocation: testAddress(city: "Iqaluit")));
       final backButtonFinder = find.byIcon(Icons.arrow_back);
       final fieldFinder = find.widgetWithText(TextFormField, "Yellowknife");
-      when(mockActiveScreenViewModel.saveEditedAtr(testATR))
+      when(mockActiveScreenViewModel.saveEditedAtr(editedATR))
           .thenAnswer((_) => Future.value()); // do nothing for test
 
       await pumpATREditingScreen(tester, testATR);

--- a/app/test/ui/views/active/dynamic_form_field/dynamic_fwr_event_form_field_test.dart
+++ b/app/test/ui/views/active/dynamic_form_field/dynamic_fwr_event_form_field_test.dart
@@ -36,17 +36,10 @@ void main() {
   }
 
   Future<void> pumpDynamicFwrFormField(
-          WidgetTester tester,
-          List<FeedWaterRestEvent> initialList,
-          Function(List<FeedWaterRestEvent>) onSaved) async =>
+          WidgetTester tester, Widget widget) async =>
       tester.pumpWidget(MaterialApp(
           home: Scaffold(
-        body: SingleChildScrollView(
-          child: dynamicFWREventFormField(
-            initialList: initialList,
-            onSaved: onSaved,
-          ),
-        ),
+        body: SingleChildScrollView(child: widget),
       )));
 
   group('Dynamic FWR Form Field', () {
@@ -84,22 +77,27 @@ void main() {
                 postalCode: "789hjk"),
             fwrProvidedOnboard: false)
       ];
-      await pumpDynamicFwrFormField(tester, testItems, (_) {
-        // do nothing for test
-      });
+      final widget = dynamicFWREventFormField(
+        initialList: testItems,
+        onSaved: (_) {
+          // do nothing for test
+        },
+      );
+      await pumpDynamicFwrFormField(tester, widget);
       await tester.pumpAndSettle();
       verifyNoDuplicateInfoShown(testItems);
     });
 
     testWidgets('shows no information when no fields',
         (WidgetTester tester) async {
-      await pumpDynamicFwrFormField(tester, <FeedWaterRestEvent>[], (_) {
-        // do nothing for test
-      });
-      expect(
-          find.text(
-              "No Feed, Water, and Rest event, add some using the + button"),
-          findsOneWidget);
+      final widget = dynamicFWREventFormField(
+        initialList: [],
+        onSaved: (_) {
+          // do nothing for test
+        },
+      );
+      await pumpDynamicFwrFormField(tester, widget);
+      expect(find.text("No Feed, Water, and Rest event"), findsOneWidget);
     });
 
     testWidgets('delete button pressed removes field',
@@ -138,9 +136,13 @@ void main() {
                 postalCode: "789hjk"),
             fwrProvidedOnboard: false)
       ];
-      await pumpDynamicFwrFormField(tester, testItems, (_) {
-        // do nothing for test
-      });
+      final widget = dynamicFWREventFormField(
+        initialList: testItems,
+        onSaved: (_) {
+          // do nothing for test
+        },
+      );
+      await pumpDynamicFwrFormField(tester, widget);
       await tester.tap(firstItemDeleteButtonFinder);
       await tester.pumpAndSettle();
       verifyInfoNotShown(itemToDelete);
@@ -173,23 +175,28 @@ void main() {
         (WidgetTester tester) async {
       final testItemToDelete = testFwrEvent();
       final deleteButtonFinder = find.byIcon(Icons.delete);
-      await pumpDynamicFwrFormField(tester, [testItemToDelete], (_) {
-        // do nothing for test
-      });
+      final widget = dynamicFWREventFormField(
+        initialList: [testItemToDelete],
+        onSaved: (_) {
+          // do nothing for test
+        },
+      );
+      await pumpDynamicFwrFormField(tester, widget);
       await tester.tap(deleteButtonFinder);
       await tester.pumpAndSettle();
-      expect(
-          find.text(
-              "No Feed, Water, and Rest event, add some using the + button"),
-          findsOneWidget);
+      expect(find.text("No Feed, Water, and Rest event"), findsOneWidget);
     });
 
     testWidgets('add button pressed adds empty field',
         (WidgetTester tester) async {
-      await pumpDynamicFwrFormField(tester, <FeedWaterRestEvent>[], (_) {
-        // do nothing for test
-      });
-      final addButtonFinder = find.byIcon(Icons.add);
+      final widget = dynamicFWREventFormField(
+        initialList: [],
+        onSaved: (_) {
+          // do nothing for test
+        },
+      );
+      await pumpDynamicFwrFormField(tester, widget);
+      final addButtonFinder = find.byIcon(Icons.add_circle);
       await tester.tap(addButtonFinder);
       await tester.pumpAndSettle();
       verifyOneEmptyFwrEventShown(FeedWaterRestEvent(
@@ -208,7 +215,7 @@ void main() {
           findsNothing);
     });
 
-    testWidgets('onSaved called when info is edited',
+    testWidgets('onSaved called when info is edited and saved',
         (WidgetTester tester) async {
       final testItems = [
         FeedWaterRestEvent(
@@ -246,10 +253,16 @@ void main() {
       List<FeedWaterRestEvent> callback;
       final onSaved = (List<FeedWaterRestEvent> changed) => callback = changed;
       final fieldFinder = find.text("FWR location 2");
-      await pumpDynamicFwrFormField(tester, testItems, onSaved);
+      final widget = dynamicFWREventFormField(
+        initialList: testItems,
+        onSaved: onSaved,
+      );
+      await pumpDynamicFwrFormField(tester, widget);
       await tester.ensureVisible(fieldFinder);
       await tester.enterText(fieldFinder, "FWR location for resting");
       await tester.pumpAndSettle();
+      // Save the form
+      widget.save();
 
       expect(callback, [
         FeedWaterRestEvent(

--- a/app/test/ui/views/active/dynamic_form_field/dynamic_string_form_field_test.dart
+++ b/app/test/ui/views/active/dynamic_form_field/dynamic_string_form_field_test.dart
@@ -1,6 +1,5 @@
 import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
 import 'package:app/ui/views/active/dynamic_form_field/dynamic_string_form_field.dart';
-import 'package:app/ui/views/active/form_field/string_form_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -13,8 +12,8 @@ void main() {
     });
   }
 
-  Future<void> pumpDynamicStringFormField(WidgetTester tester,
-          DynamicFormField<String, StringFormField> widget) async =>
+  Future<void> pumpDynamicStringFormField(
+          WidgetTester tester, DynamicFormField<String> widget) async =>
       tester.pumpWidget(MaterialApp(
           home: Scaffold(
         body: widget,
@@ -47,8 +46,7 @@ void main() {
         },
       );
       await pumpDynamicStringFormField(tester, widget);
-      expect(find.text("No Test Title, add some using the + button"),
-          findsOneWidget);
+      expect(find.text("No Test Title"), findsOneWidget);
     });
 
     testWidgets('delete button pressed removes field',
@@ -86,8 +84,7 @@ void main() {
       await pumpDynamicStringFormField(tester, widget);
       await tester.tap(deleteButtonFinder);
       await tester.pumpAndSettle();
-      expect(find.text("No $testTitle, add some using the + button"),
-          findsOneWidget);
+      expect(find.text("No $testTitle"), findsOneWidget);
     });
 
     testWidgets('add button pressed adds empty field',
@@ -101,15 +98,14 @@ void main() {
         },
       );
       await pumpDynamicStringFormField(tester, widget);
-      final addButtonFinder = find.byIcon(Icons.add);
+      final addButtonFinder = find.byIcon(Icons.add_circle);
       await tester.tap(addButtonFinder);
       await tester.pumpAndSettle();
       verifyNoDuplicateInfoShown(testTitle, [""]);
-      expect(find.text("No $testTitle, add some using the + button"),
-          findsNothing);
+      expect(find.text("No $testTitle"), findsNothing);
     });
 
-    testWidgets('onSaved called when info is edited',
+    testWidgets('onSaved called when info is edited then saved',
         (WidgetTester tester) async {
       final testTitle = "Test Title";
       final testItems = ["Test0", "Test1", "Test2"];
@@ -117,7 +113,7 @@ void main() {
       List<String> callback;
       final onSaved = (List<String> changed) => callback = changed;
       final fieldFinder = find.text("Test0");
-      final widget = dynamicStringFormField(
+      final DynamicFormField<String> widget = dynamicStringFormField(
         initialList: testItems,
         titles: testTitle,
         onSaved: onSaved,
@@ -125,6 +121,7 @@ void main() {
       await pumpDynamicStringFormField(tester, widget);
       await tester.enterText(fieldFinder, "Test3");
       await tester.pumpAndSettle();
+      widget.save();
       expect(callback, editedItems);
     });
   });

--- a/app/test/ui/views/active/form_field/address_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/address_form_field_test.dart
@@ -6,8 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  Future<void> pumpAddressFormField(
-          WidgetTester tester, AddressFormField widget) async =>
+  Future<void> pumpAddressFormField(WidgetTester tester, Widget widget) async =>
       tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
 
   group('Address Form Field', () {
@@ -28,7 +27,7 @@ void main() {
       verifyAddressIsShown(testAddr);
     });
 
-    testWidgets('onSaved called when info is edited',
+    testWidgets('onSaved called when info is edited and saved',
         (WidgetTester tester) async {
       final initialStreet = "ABC Street";
       final editedStreet = "Edited Street";
@@ -37,13 +36,18 @@ void main() {
       Address callback;
       final onSaved = (Address changed) => callback = changed;
       final fieldFinder = find.text(initialStreet);
-      final widget = AddressFormField(
-        initialAddr: testAddr,
-        onSaved: onSaved,
+      final formKey = GlobalKey<FormState>();
+      final widget = Form(
+        key: formKey,
+        child: AddressFormField(
+          initialAddr: testAddr,
+          onSaved: onSaved,
+        ),
       );
       await pumpAddressFormField(tester, widget);
       await tester.enterText(fieldFinder, editedStreet);
       await tester.pumpAndSettle();
+      formKey.currentState.save();
       expect(callback, editedAddr);
     });
   });

--- a/app/test/ui/views/active/form_field/animal_group_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/animal_group_form_field_test.dart
@@ -7,19 +7,12 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   Future<void> pumpAnimalGroupFormField(
-          WidgetTester tester,
-          AnimalGroup testInfo,
-          Function(AnimalGroup) onSaved,
-          Function() onDelete) async =>
+          WidgetTester tester, Widget widget) async =>
       tester.pumpWidget(MaterialApp(
           home: Scaffold(
               body: SingleChildScrollView(
                   child: Container(
-        child: AnimalGroupFormField(
-          initialInfo: testInfo,
-          onSaved: onSaved,
-          onDelete: onDelete,
-        ),
+        child: widget,
       )))));
 
   group('Animal Group Form Field', () {
@@ -38,11 +31,16 @@ void main() {
                 measuresTakenToCareForAnimal:
                     "Rendered cow unconscious for travel")
           ]);
-      await pumpAnimalGroupFormField(tester, testAnimalGroup, (_) {
-        // Do nothing for test
-      }, () {
-        // Do nothing for test
-      });
+      final widget = AnimalGroupFormField(
+        initial: testAnimalGroup,
+        onSaved: (_) {
+          // Do nothing for test
+        },
+        onDelete: () {
+          // Do nothing for test
+        },
+      );
+      await pumpAnimalGroupFormField(tester, widget);
       verifyAnimalGroupIsShown(testAnimalGroup);
     });
 
@@ -51,9 +49,14 @@ void main() {
       bool callback;
       final onDeleteCallback = () => callback = true;
       final deleteButtonFinder = find.byIcon(Icons.delete);
-      await pumpAnimalGroupFormField(tester, testAnimalGroup(), (_) {
-        // do nothing for test
-      }, onDeleteCallback);
+      final widget = AnimalGroupFormField(
+        initial: testAnimalGroup(),
+        onSaved: (_) {
+          // Do nothing for test
+        },
+        onDelete: onDeleteCallback,
+      );
+      await pumpAnimalGroupFormField(tester, widget);
       await tester.ensureVisible(deleteButtonFinder);
       await tester.tap(deleteButtonFinder);
       await tester.pumpAndSettle();
@@ -74,13 +77,21 @@ void main() {
       AnimalGroup callback;
       final onSaved = (AnimalGroup changed) => callback = changed;
       final fieldFinder = find.text(testDescription);
-
-      await pumpAnimalGroupFormField(tester, testInfo, onSaved, () {
-        // Do nothing for test
-      });
+      final formKey = GlobalKey<FormState>();
+      final widget = Form(
+          key: formKey,
+          child: AnimalGroupFormField(
+            initial: testInfo,
+            onSaved: onSaved,
+            onDelete: () {
+              // Do nothing for test
+            },
+          ));
+      await pumpAnimalGroupFormField(tester, widget);
       await tester.ensureVisible(fieldFinder);
       await tester.enterText(fieldFinder, editedDescription);
       await tester.pumpAndSettle();
+      formKey.currentState.save();
       expect(callback, editedInfo);
     });
   });

--- a/app/test/ui/views/active/form_field/compromised_animal_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/compromised_animal_form_field_test.dart
@@ -7,18 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   Future<void> pumpCompromisedAnimalFormField(
-          WidgetTester tester,
-          CompromisedAnimal initial,
-          Function(CompromisedAnimal) onSaved,
-          Function() onDelete) async =>
-      tester.pumpWidget(MaterialApp(
-          home: Scaffold(
-              body: CompromisedAnimalFormField(
-        title: "Compromised Animal",
-        initial: initial,
-        onSaved: onSaved,
-        onDelete: onDelete,
-      ))));
+          WidgetTester tester, Widget widget) async =>
+      tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
 
   group('Compromised Animal Form Field', () {
     testWidgets('shows right information', (WidgetTester tester) async {
@@ -26,11 +16,16 @@ void main() {
           animalDescription: "Chicken with bad leg",
           measuresTakenToCareForAnimal:
               "Wrapped the leg in bandages and stint");
-      await pumpCompromisedAnimalFormField(tester, compromisedAnimal, (_) {
-        // do nothing for test
-      }, () {
-        // do nothing for test
-      });
+      final widget = CompromisedAnimalFormField(
+          title: "Compromised Animal",
+          initial: compromisedAnimal,
+          onSaved: (_) {
+            // do nothing for test
+          },
+          onDelete: () {
+            // do nothing for test
+          });
+      await pumpCompromisedAnimalFormField(tester, widget);
       verifyCompromisedAnimalInfoIsShown(compromisedAnimal);
     });
 
@@ -39,17 +34,22 @@ void main() {
       bool callback;
       final onDeleteCallback = () => callback = true;
       final deleteButtonFinder = find.byIcon(Icons.delete);
-      await pumpCompromisedAnimalFormField(tester, testCompromisedAnimal(),
-          (_) {
-        // do nothing for test
-      }, onDeleteCallback);
+      final widget = CompromisedAnimalFormField(
+          title: "Compromised Animal",
+          initial: testCompromisedAnimal(),
+          onSaved: (_) {
+            // do nothing for test
+          },
+          onDelete: onDeleteCallback);
+      await pumpCompromisedAnimalFormField(tester, widget);
       await tester.ensureVisible(deleteButtonFinder);
       await tester.tap(deleteButtonFinder);
       await tester.pumpAndSettle();
       expect(callback, isTrue);
     });
 
-    testWidgets('onSaved called when edited', (WidgetTester tester) async {
+    testWidgets('onSaved called when edited and saved',
+        (WidgetTester tester) async {
       final testDescription = "Chicken bad leg";
       final editedDescription = "Turkey bad leg";
       CompromisedAnimal callback;
@@ -61,13 +61,21 @@ void main() {
           testCompromisedAnimal(animalDescription: testDescription);
       final editedCompromisedAnimal =
           testCompromisedAnimal(animalDescription: editedDescription);
-
-      await pumpCompromisedAnimalFormField(tester, testAnimal, onSavedCallback,
-          () {
-        // do nothing for test
-      });
+      final formKey = GlobalKey<FormState>();
+      final widget = Form(
+        key: formKey,
+        child: CompromisedAnimalFormField(
+            title: "Compromised Animal",
+            initial: testAnimal,
+            onSaved: onSavedCallback,
+            onDelete: () {
+              // do nothing for test
+            }),
+      );
+      await pumpCompromisedAnimalFormField(tester, widget);
       await tester.enterText(fieldFinder, editedDescription);
       await tester.pumpAndSettle();
+      formKey.currentState.save();
       // expect was saved
       expect(callback, editedCompromisedAnimal);
       // expect edited text visible

--- a/app/test/ui/views/active/form_field/contingency_activity_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/contingency_activity_form_field_test.dart
@@ -7,30 +7,26 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   Future<void> pumpContingencyActivityFormField(
-          WidgetTester tester,
-          ContingencyActivity initial,
-          Function(ContingencyActivity) onSaved,
-          Function() onDelete) async =>
-      tester.pumpWidget(MaterialApp(
-          home: Scaffold(
-              body: ContingencyActivityFormField(
-        initial: initial,
-        onSaved: onSaved,
-        onDelete: onDelete,
-      ))));
+          WidgetTester tester, Widget widget) async =>
+      tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
 
   group('Contingency Activity Form Field', () {
     testWidgets('shows right information', (WidgetTester tester) async {
       final contingencyActivity = ContingencyActivity(
-          time: TimeOfDay.fromDateTime(DateTime.parse("0000-01-01 19:22")),
+          time: DateTime.parse("1970-01-01 19:22"),
           personContacted: "Jamie Hill",
           methodOfContact: "Phone call",
           instructionsGiven: "Wait for authorities to arrive");
-      await pumpContingencyActivityFormField(tester, contingencyActivity, (_) {
-        // do nothing for test
-      }, () {
-        // do nothing for test
-      });
+      final widget = ContingencyActivityFormField(
+        initial: contingencyActivity,
+        onSaved: (_) {
+          // do nothing for test
+        },
+        onDelete: () {
+          // do nothing for test
+        },
+      );
+      await pumpContingencyActivityFormField(tester, widget);
       verifyContingencyActivityShown(contingencyActivity);
     });
 
@@ -39,17 +35,22 @@ void main() {
       bool callback;
       final onDeleteCallback = () => callback = true;
       final deleteButtonFinder = find.byIcon(Icons.delete);
-      await pumpContingencyActivityFormField(tester, testContingencyActivity(),
-          (_) {
-        // do nothing for test
-      }, onDeleteCallback);
+      final widget = ContingencyActivityFormField(
+        initial: testContingencyActivity(),
+        onSaved: (_) {
+          // do nothing for test
+        },
+        onDelete: onDeleteCallback,
+      );
+      await pumpContingencyActivityFormField(tester, widget);
       await tester.ensureVisible(deleteButtonFinder);
       await tester.tap(deleteButtonFinder);
       await tester.pumpAndSettle();
       expect(callback, isTrue);
     });
 
-    testWidgets('onSaved called when edited', (WidgetTester tester) async {
+    testWidgets('onSaved called when edited and saved',
+        (WidgetTester tester) async {
       final testContact = "Jamie Foxx";
       final editedContact = "Meghan Foxx";
       ContingencyActivity callback;
@@ -62,13 +63,20 @@ void main() {
           testContingencyActivity(personContacted: testContact);
       final editedActivity =
           testContingencyActivity(personContacted: editedContact);
-
-      await pumpContingencyActivityFormField(
-          tester, testActivity, onSavedCallback, () {
-        // do nothing for test
-      });
+      final formKey = GlobalKey<FormState>();
+      final widget = Form(
+          key: formKey,
+          child: ContingencyActivityFormField(
+            initial: testActivity,
+            onSaved: onSavedCallback,
+            onDelete: () {
+              // do nothing for test
+            },
+          ));
+      await pumpContingencyActivityFormField(tester, widget);
       await tester.enterText(fieldFinder, editedContact);
       await tester.pumpAndSettle();
+      formKey.currentState.save();
       // expect was saved
       expect(callback, editedActivity);
       // expect edited text visible

--- a/app/test/ui/views/active/form_field/contingency_plan_event_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/contingency_plan_event_form_field_test.dart
@@ -7,18 +7,11 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   Future<void> pumpContingencyPlanEventFormField(
-          WidgetTester tester,
-          ContingencyPlanEvent initial,
-          Function(ContingencyPlanEvent) onSaved,
-          Function() onDelete) async =>
+          WidgetTester tester, Widget widget) async =>
       tester.pumpWidget(MaterialApp(
           home: Scaffold(
               body: SingleChildScrollView(
-        child: ContingencyPlanEventFormField(
-          initial: initial,
-          onSaved: onSaved,
-          onDelete: onDelete,
-        ),
+        child: widget,
       ))));
 
   group('Contingency Plan Event Form Field', () {
@@ -30,11 +23,16 @@ void main() {
           disturbancesIdentified: "Cow was bleeding heavily",
           activities: [testContingencyActivity()],
           actionsTaken: ["Bandaged up cow"]);
-      await pumpContingencyPlanEventFormField(tester, contingencyEvent, (_) {
-        // do nothing for test
-      }, () {
-        // do nothing for test
-      });
+      final widget = ContingencyPlanEventFormField(
+        initial: contingencyEvent,
+        onSaved: (_) {
+          // do nothing for test
+        },
+        onDelete: () {
+          // do nothing for test
+        },
+      );
+      await pumpContingencyPlanEventFormField(tester, widget);
       verifyContingencyPlanEventShown(contingencyEvent);
     });
 
@@ -43,17 +41,21 @@ void main() {
       bool callback;
       final onDeleteCallback = () => callback = true;
       final deleteButtonFinder = find.byIcon(Icons.delete).first;
-      await pumpContingencyPlanEventFormField(tester, testContingencyEvent(),
-          (_) {
-        // do nothing for test
-      }, onDeleteCallback);
+      final widget = ContingencyPlanEventFormField(
+        initial: testContingencyEvent(),
+        onSaved: (_) {
+          // do nothing for test
+        },
+        onDelete: onDeleteCallback,
+      );
+      await pumpContingencyPlanEventFormField(tester, widget);
       await tester.ensureVisible(deleteButtonFinder);
       await tester.tap(deleteButtonFinder);
       await tester.pumpAndSettle();
       expect(callback, isTrue);
     });
 
-    testWidgets('onSaved called when contingency activity edited',
+    testWidgets('onSaved called when contingency activity edited and saved',
         (WidgetTester tester) async {
       final testContact = "Jamie Foxx";
       final editedContact = "Meghan Foxx";
@@ -68,13 +70,20 @@ void main() {
       final editedEvent = testContingencyEvent(activities: [
         testContingencyActivity(personContacted: editedContact)
       ]);
-
-      await pumpContingencyPlanEventFormField(
-          tester, testEvent, onSavedCallback, () {
-        // do nothing for test
-      });
+      final formKey = GlobalKey<FormState>();
+      final widget = Form(
+          key: formKey,
+          child: ContingencyPlanEventFormField(
+            initial: testEvent,
+            onSaved: onSavedCallback,
+            onDelete: () {
+              // do nothing for test
+            },
+          ));
+      await pumpContingencyPlanEventFormField(tester, widget);
       await tester.enterText(fieldFinder, editedContact);
       await tester.pumpAndSettle();
+      formKey.currentState.save();
       // expect was saved
       expect(callback, editedEvent);
       // expect edited text visible

--- a/app/test/ui/views/active/form_field/contingency_plan_info_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/contingency_plan_info_form_field_test.dart
@@ -26,15 +26,12 @@ void main() {
   }
 
   Future<void> pumpContingencyPlanInfoFormField(
-          WidgetTester tester,
-          ContingencyPlanInfo testInfo,
-          Function(ContingencyPlanInfo) callback) async =>
+          WidgetTester tester, Widget widget) async =>
       tester.pumpWidget(MaterialApp(
           home: Scaffold(
               body: SingleChildScrollView(
                   child: Container(
-        child: ContingencyPlanInfoFormField(
-            initialInfo: testInfo, onSaved: callback),
+        child: widget,
       )))));
 
   group('Contingency Plan Info Form Field', () {
@@ -50,18 +47,23 @@ void main() {
             "Team Rocket blasting off at the speed of light!"
           ],
           contingencyEvents: []);
-      await pumpContingencyPlanInfoFormField(tester, contingencyPlanInfo, (_) {
-        // Do nothing for test
-      });
+      final widget = ContingencyPlanInfoFormField(
+          initialInfo: contingencyPlanInfo,
+          onSaved: (_) {
+            // Do nothing for test
+          });
+      await pumpContingencyPlanInfoFormField(tester, widget);
       verifyInformationIsShown(contingencyPlanInfo);
     });
 
     testWidgets('shows save button', (WidgetTester tester) async {
       final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
-      await pumpContingencyPlanInfoFormField(tester, testContingencyInfo(),
-          (_) {
-        // Do nothing for test
-      });
+      final widget = ContingencyPlanInfoFormField(
+          initialInfo: testContingencyInfo(),
+          onSaved: (_) {
+            // Do nothing for test
+          });
+      await pumpContingencyPlanInfoFormField(tester, widget);
       await tester.ensureVisible(saveButtonFinder);
       expect(saveButtonFinder, findsOneWidget);
     });
@@ -73,7 +75,9 @@ void main() {
       ContingencyPlanInfo callbackInfo;
       final onSavedCallback = (ContingencyPlanInfo info) => callbackInfo = info;
 
-      await pumpContingencyPlanInfoFormField(tester, testInfo, onSavedCallback);
+      final widget = ContingencyPlanInfoFormField(
+          initialInfo: testInfo, onSaved: onSavedCallback);
+      await pumpContingencyPlanInfoFormField(tester, widget);
       await tester.ensureVisible(saveButtonFinder);
       await tester.tap(saveButtonFinder);
       await tester.pumpAndSettle();
@@ -96,7 +100,9 @@ void main() {
       ]);
       final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
 
-      await pumpContingencyPlanInfoFormField(tester, testInfo, onSaved);
+      final widget =
+          ContingencyPlanInfoFormField(initialInfo: testInfo, onSaved: onSaved);
+      await pumpContingencyPlanInfoFormField(tester, widget);
       // Edit text
       await tester.ensureVisible(fieldFinder);
       await tester.enterText(fieldFinder, editedContact);

--- a/app/test/ui/views/active/form_field/fwr_event_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/fwr_event_form_field_test.dart
@@ -8,18 +8,11 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   Future<void> pumpFwrEventFormField(
-          WidgetTester tester,
-          FeedWaterRestEvent initial,
-          Function(FeedWaterRestEvent) onSaved,
-          Function() onDelete) async =>
+          WidgetTester tester, Widget widget) async =>
       tester.pumpWidget(MaterialApp(
           home: Scaffold(
               body: SingleChildScrollView(
-        child: FeedWaterRestEventFormField(
-          initial: initial,
-          onSaved: onSaved,
-          onDelete: onDelete,
-        ),
+        child: widget,
       ))));
 
   group('Feed, Water, and Rest Event Form Field', () {
@@ -34,11 +27,16 @@ void main() {
               country: "FWR country",
               postalCode: "234rty"),
           fwrProvidedOnboard: false);
-      await pumpFwrEventFormField(tester, feedWaterRestEvent, (_) {
-        // do nothing for test
-      }, () {
-        // do nothing for test
-      });
+      final widget = FeedWaterRestEventFormField(
+        initial: feedWaterRestEvent,
+        onSaved: (_) {
+          // do nothing for test
+        },
+        onDelete: () {
+          // do nothing for test
+        },
+      );
+      await pumpFwrEventFormField(tester, widget);
       verifyFwrEventInformationIsShown(feedWaterRestEvent);
     });
 
@@ -47,9 +45,14 @@ void main() {
       bool callback;
       final onDeleteCallback = () => callback = true;
       final deleteButtonFinder = find.byIcon(Icons.delete);
-      await pumpFwrEventFormField(tester, testFwrEvent(), (_) {
-        // do nothing for test
-      }, onDeleteCallback);
+      final widget = FeedWaterRestEventFormField(
+        initial: testFwrEvent(),
+        onSaved: (_) {
+          // do nothing for test
+        },
+        onDelete: onDeleteCallback,
+      );
+      await pumpFwrEventFormField(tester, widget);
       await tester.ensureVisible(deleteButtonFinder);
       await tester.tap(deleteButtonFinder);
       await tester.pumpAndSettle();
@@ -69,13 +72,20 @@ void main() {
           testFwrEvent(lastFwrLocation: testAddress(streetAddress: testStreet));
       final editedFeedWaterRestEvent = testFwrEvent(
           lastFwrLocation: testAddress(streetAddress: editedStreet));
-
-      await pumpFwrEventFormField(
-          tester, testFeedWaterRestEvent, onSavedCallback, () {
-        // do nothing for test
-      });
+      final formKey = GlobalKey<FormState>();
+      final widget = Form(
+          key: formKey,
+          child: FeedWaterRestEventFormField(
+            initial: testFeedWaterRestEvent,
+            onSaved: onSavedCallback,
+            onDelete: () {
+              // do nothing for test
+            },
+          ));
+      await pumpFwrEventFormField(tester, widget);
       await tester.enterText(fieldFinder, editedStreet);
       await tester.pumpAndSettle();
+      formKey.currentState.save();
       // expect was saved
       expect(callback, editedFeedWaterRestEvent);
       // expect edited text visible

--- a/app/test/ui/views/active/form_field/int_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/int_form_field_test.dart
@@ -9,8 +9,7 @@ void main() {
     expect(find.widgetWithText(ListTile, titleExpected), findsOneWidget);
   }
 
-  Future<void> pumpIntFormField(
-          WidgetTester tester, IntFormField widget) async =>
+  Future<void> pumpIntFormField(WidgetTester tester, Widget widget) async =>
       tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
 
   group('Integer Form Field', () {
@@ -37,15 +36,19 @@ void main() {
           find.widgetWithText(TextFormField, testInfo.toString());
       final editedFieldFinder =
           find.widgetWithText(TextFormField, editedInfo.toString());
-      final widget = IntFormField(
-        initial: testInfo,
-        title: "Test Title",
-        onSaved: onSavedCallback,
-      );
+      final formKey = GlobalKey<FormState>();
+      final widget = Form(
+          key: formKey,
+          child: IntFormField(
+            initial: testInfo,
+            title: "Test Title",
+            onSaved: onSavedCallback,
+          ));
 
       await pumpIntFormField(tester, widget);
       await tester.enterText(fieldFinder, editedInfo.toString());
       await tester.pumpAndSettle();
+      formKey.currentState.save();
       // expect was saved
       expect(callback, editedInfo);
       // expect edited text visible

--- a/app/test/ui/views/active/form_field/receiver_info_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/receiver_info_form_field_test.dart
@@ -7,15 +7,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  Future<void> pumpReceiverInfoFormField(WidgetTester tester,
-          ReceiverInfo initial, Function(ReceiverInfo) onSaved) async =>
+  Future<void> pumpReceiverInfoFormField(
+          WidgetTester tester, Widget widget) async =>
       tester.pumpWidget(MaterialApp(
           home: Scaffold(
               body: SingleChildScrollView(
-        child: ReceiverInfoFormField(
-          initialInfo: initial,
-          onSaved: onSaved,
-        ),
+        child: widget,
       ))));
 
   group('Receiver Info Form Field', () {
@@ -28,9 +25,13 @@ void main() {
           destinationLocationName: "Tester Company Farms",
           destinationAddress: testAddress(),
           receiverContactInfo: "By phone: 3061111111");
-      await pumpReceiverInfoFormField(tester, testReceiverInfo, (_) {
-        // do nothing for test
-      });
+      final widget = ReceiverInfoFormField(
+        initialInfo: testReceiverInfo,
+        onSaved: (_) {
+          // do nothing for test
+        },
+      );
+      await pumpReceiverInfoFormField(tester, widget);
       verifyReceiverInfoIsShown(testReceiverInfo);
     });
 
@@ -45,9 +46,17 @@ void main() {
       final testRecInfo = testReceiverInfo(accountId: testAccountId);
       final editedRecInfo = testReceiverInfo(accountId: editedAccountId);
 
-      await pumpReceiverInfoFormField(tester, testRecInfo, onSavedCallback);
+      final formKey = GlobalKey<FormState>();
+      final widget = Form(
+          key: formKey,
+          child: ReceiverInfoFormField(
+            initialInfo: testRecInfo,
+            onSaved: onSavedCallback,
+          ));
+      await pumpReceiverInfoFormField(tester, widget);
       await tester.enterText(fieldFinder, "123");
       await tester.pumpAndSettle();
+      formKey.currentState.save();
       // expect was saved
       expect(callback, editedRecInfo);
       // expect edited text visible

--- a/app/test/ui/views/active/form_field/string_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/string_form_field_test.dart
@@ -9,8 +9,7 @@ void main() {
     expect(find.widgetWithText(ListTile, titleExpected), findsOneWidget);
   }
 
-  Future<void> pumpStringFormField(
-          WidgetTester tester, StringFormField widget) async =>
+  Future<void> pumpStringFormField(WidgetTester tester, Widget widget) async =>
       tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
 
   group('String Form Field', () {
@@ -64,23 +63,28 @@ void main() {
       expect(deleteButtonFinder, findsNothing);
     });
 
-    testWidgets('onSaved called when edited', (WidgetTester tester) async {
+    testWidgets('onSaved called when edited then saved',
+        (WidgetTester tester) async {
       final testInfo = "Test";
       final editedInfo = "Edited";
       String callback;
       final onSavedCallback = (String changed) => callback = changed;
       final fieldFinder = find.widgetWithText(TextFormField, testInfo);
       final editedFieldFinder = find.widgetWithText(TextFormField, editedInfo);
-      final widget = StringFormField(
-        initial: testInfo,
-        title: "Test Title",
-        onSaved: onSavedCallback,
-        onDelete: Optional.empty(),
-      );
+      final testFormKey = GlobalKey<FormState>();
+      final widget = Form(
+          key: testFormKey,
+          child: StringFormField(
+            initial: testInfo,
+            title: "Test Title",
+            onSaved: onSavedCallback,
+            onDelete: Optional.empty(),
+          ));
 
       await pumpStringFormField(tester, widget);
       await tester.enterText(fieldFinder, editedInfo);
       await tester.pumpAndSettle();
+      testFormKey.currentState.save();
       // expect was saved
       expect(callback, editedInfo);
       // expect edited text visible

--- a/app/test/ui/views/active/form_field/transporter_info_form_field_test.dart
+++ b/app/test/ui/views/active/form_field/transporter_info_form_field_test.dart
@@ -142,7 +142,7 @@ void main() {
       final testInfo = testTransporterInfo(driverNames: initialNames);
       final expectedEditedInfo = testTransporterInfo(driverNames: editedNames);
 
-      final addButtonFinder = find.byIcon(Icons.add);
+      final addButtonFinder = find.byIcon(Icons.add_circle);
       final saveButtonFinder = find.widgetWithText(RaisedButton, "Save");
       final emptyDriverNameFieldFinder = find.widgetWithText(TextFormField, "");
 


### PR DESCRIPTION
The big part of #205. Some TODOs are mistakenly 136 or 134. I'll being going through app TODOs and assigning them next PR.

In this PR I have done:
1. Update all form fields to have some form of validation
2. Update the form fields to have the outlined box decoration. Maybe this is possible using app theme.
3. Update the editing screen so saving the ATR when backing out (not hitting save or submit buttons) saves as-is
4. Update the save and submit buttons to validate their respective forms
> Validation, when called outside the state you're validating, will not cause the red text to appear. The save button in that widget will cause the red text to appear. 
>
> So, when hitting submit, we can't make the red text appear, but we can tell the transporter which section needs to be looked at again. I'll be doing this in the next PR.
5. Update `DynamicFormField` to be less generically confusing, also dropped the expensive `ListView.builder` shrink wrap
6. Updated tests accordingly
7. Fixed a hidden bug with the `TimeOfDay` type and the database. It should be `DateTime` where we ignore the date. Changed accordingly

I'll be leaving further GUI changes to the form fields to #214 (like making the menus larger, adding white text to the save and submit buttons, because they're black now as seen in the video (hard to see))

***

Changes look like:


https://user-images.githubusercontent.com/32527219/111082800-c4d01500-84cf-11eb-97b5-0978c72dff2b.mp4


https://user-images.githubusercontent.com/32527219/111082801-c7326f00-84cf-11eb-8c34-9d677277ff15.mp4


https://user-images.githubusercontent.com/32527219/111082807-cbf72300-84cf-11eb-9191-4033c1bd2d1e.mp4

