### PR TITLE
Added query to upload images to firebase_storage

### DIFF
--- a/app/lib/core/services/database/database_interface.dart
+++ b/app/lib/core/services/database/database_interface.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:app/core/models/animal_transport_record.dart';
 import 'package:app/core/models/transporter.dart';
 
@@ -17,6 +19,8 @@ abstract class DatabaseInterface {
   Future<void> updateAtr(AnimalTransportRecord atr);
 
   Future<void> removeAtr(String atrId);
+
+  Future<String> uploadAtrImage(File file, String fileName);
 
   Future<List<AnimalTransportRecord>> getCompleteRecords(String userId);
 

--- a/app/lib/core/services/database/database_service.dart
+++ b/app/lib/core/services/database/database_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:app/core/models/animal_transport_record.dart';
 import 'package:app/core/models/transporter.dart';
@@ -37,6 +38,9 @@ class DatabaseService {
 
   Future<List<AnimalTransportRecord>> getCompleteRecords(String userId) async =>
       interface.getCompleteRecords(userId);
+
+  Future<String> uploadAtrImage(File file, String fileName) async =>
+      interface.uploadAtrImage(file, fileName);
 
   Stream<List<AnimalTransportRecord>> getUpdatedCompleteATRs(String userId) =>
       interface.getUpdatedCompleteATRs(userId);

--- a/app/lib/core/services/database/firebase_database_interface.dart
+++ b/app/lib/core/services/database/firebase_database_interface.dart
@@ -1,14 +1,16 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:app/core/models/animal_transport_record.dart';
 import 'package:app/core/models/transporter.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 
 import 'database_interface.dart';
 
 class FirebaseDatabaseInterface implements DatabaseInterface {
   final FirebaseFirestore _firestore;
-
+  final _firebaseStorage = FirebaseStorage.instance;
   FirebaseDatabaseInterface(this._firestore);
 
   @override
@@ -101,4 +103,12 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
           .map((snapshot) => snapshot.docs
               .map((doc) => AnimalTransportRecord.fromJSON(doc.data(), doc.id))
               .toList());
+
+  @override
+  Future<String> uploadAtrImage(File file, String fileName) async =>
+      _firebaseStorage
+          .ref()
+          .child('atrImages/$fileName')
+          .putFile(file)
+          .then((TaskSnapshot snapshot) => snapshot.ref.getDownloadURL());
 }

--- a/app/lib/core/services/database/firebase_database_interface.dart
+++ b/app/lib/core/services/database/firebase_database_interface.dart
@@ -10,7 +10,6 @@ import 'database_interface.dart';
 
 class FirebaseDatabaseInterface implements DatabaseInterface {
   final FirebaseFirestore _firestore;
-  final _firebaseStorage = FirebaseStorage.instance;
   FirebaseDatabaseInterface(this._firestore);
 
   @override
@@ -106,7 +105,7 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
 
   @override
   Future<String> uploadAtrImage(File file, String fileName) async =>
-      _firebaseStorage
+      FirebaseStorage.instance
           .ref()
           .child('atrImages/$fileName')
           .putFile(file)

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -232,6 +232,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1+3"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.0.0"
+  firebase_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_storage_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
+  firebase_storage_web:
+    dependency: transitive
+    description:
+      name: firebase_storage_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1+3"
   fixnum:
     dependency: transitive
     description:
@@ -509,6 +530,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.2"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.0+2"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   petitparser:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -28,19 +28,21 @@ dependencies:
   date_time_picker: ^1.1.1
   firebase_auth: ^0.20.0+1
   firebase_core: ^0.7.0
+  firebase_storage: ^7.0.0
   flutter_email_sender: ^4.0.0
   flutter_full_pdf_viewer: ^1.0.6
+  flutter_launcher_icons: ^0.8.0
   flutter_multi_formatter: ^1.3.6
   get_it: ^5.0.6
+  hexcolor: ^1.0.6
   image_picker: ^0.6.7+21
   mockito: ^4.1.4
   path_provider: ^1.5.1
   pdf: ^2.0.0
+  permission_handler: ^5.0.1+1
   provider: ^4.3.2+3
   sqflite: ^1.3.2+2
   uuid: 2.2.2
-  flutter_launcher_icons: ^0.8.0
-  hexcolor: ^1.0.6
   google_fonts: ^1.1.2
 
 dev_dependencies:


### PR DESCRIPTION
Added a query that will create the ability to upload images to firebase storage. Possible tasks that could be open is the ViewModel that will use the service itself. I also added a really useful plugin called permission_handler where it can be use in the viewmodel by checking the permission.

[Link](https://www.youtube.com/watch?v=KmyhznxYQ70&t=1096s&ab_channel=AndyJulow) to the tutorial I followed for this task.