### PR TITLE
Add set as default ATR button

### DIFF
--- a/app/lib/core/models/acknowledgement_info.dart
+++ b/app/lib/core/models/acknowledgement_info.dart
@@ -12,7 +12,7 @@ class AcknowledgementInfo {
       @required this.transporterAck,
       @required this.receiverAck});
 
-  factory AcknowledgementInfo.defaultAckInfo() =>
+  factory AcknowledgementInfo.empty() =>
       AcknowledgementInfo(shipperAck: "", transporterAck: "", receiverAck: "");
 
   @override

--- a/app/lib/core/models/animal_transport_record.dart
+++ b/app/lib/core/models/animal_transport_record.dart
@@ -31,17 +31,26 @@ class AnimalTransportRecord {
     @required this.identifier,
   });
 
-  factory AnimalTransportRecord.defaultAtr(String userId) =>
-      AnimalTransportRecord(
-        shipInfo: ShipperInfo.defaultShipperInfo(),
-        tranInfo: TransporterInfo.defaultTransporterInfo(),
-        fwrInfo: FeedWaterRestInfo.defaultFwrInfo(),
-        vehicleInfo: LoadingVehicleInfo.defaultVehicleInfo(),
-        deliveryInfo: DeliveryInfo.defaultDeliveryInfo(),
-        ackInfo: AcknowledgementInfo.defaultAckInfo(),
-        contingencyInfo: ContingencyPlanInfo.defaultContingencyInfo(),
+  factory AnimalTransportRecord.empty(String userId) => AnimalTransportRecord(
+        shipInfo: ShipperInfo.empty(),
+        tranInfo: TransporterInfo.empty(),
+        fwrInfo: FeedWaterRestInfo.empty(),
+        vehicleInfo: LoadingVehicleInfo.empty(),
+        deliveryInfo: DeliveryInfo.empty(),
+        ackInfo: AcknowledgementInfo.empty(),
+        contingencyInfo: ContingencyPlanInfo.empty(),
         identifier: AtrIdentifier.defaultAtrIdentifier(userId),
       );
+
+  AnimalTransportRecord asDefault() => AnimalTransportRecord(
+      shipInfo: shipInfo,
+      tranInfo: tranInfo,
+      fwrInfo: FeedWaterRestInfo.empty(),
+      vehicleInfo: LoadingVehicleInfo.empty(),
+      deliveryInfo: deliveryInfo.withJustReceiverInfo(),
+      ackInfo: AcknowledgementInfo.empty(),
+      contingencyInfo: contingencyInfo.withoutContingencyEvents(),
+      identifier: AtrIdentifier.defaultAtrIdentifier(identifier.userId));
 
   @override
   int get hashCode =>

--- a/app/lib/core/models/contingency_plan_info.dart
+++ b/app/lib/core/models/contingency_plan_info.dart
@@ -28,7 +28,7 @@ class ContingencyPlanInfo {
         _potentialSafetyActions = potentialSafetyActions,
         _contingencyEvents = contingencyEvents;
 
-  factory ContingencyPlanInfo.defaultContingencyInfo() => ContingencyPlanInfo(
+  factory ContingencyPlanInfo.empty() => ContingencyPlanInfo(
       goalStatement: "",
       communicationPlan: "",
       crisisContacts: [],
@@ -36,6 +36,16 @@ class ContingencyPlanInfo {
       standardAnimalMonitoring: "",
       potentialHazards: [],
       potentialSafetyActions: [],
+      contingencyEvents: []);
+
+  ContingencyPlanInfo withoutContingencyEvents() => ContingencyPlanInfo(
+      goalStatement: goalStatement,
+      communicationPlan: communicationPlan,
+      crisisContacts: crisisContacts,
+      expectedPrepProcess: expectedPrepProcess,
+      standardAnimalMonitoring: standardAnimalMonitoring,
+      potentialHazards: potentialHazards,
+      potentialSafetyActions: potentialSafetyActions,
       contingencyEvents: []);
 
   @override

--- a/app/lib/core/models/delivery_info.dart
+++ b/app/lib/core/models/delivery_info.dart
@@ -20,8 +20,14 @@ class DeliveryInfo {
       @required this.additionalWelfareConcerns})
       : _compromisedAnimals = compromisedAnimals;
 
-  factory DeliveryInfo.defaultDeliveryInfo() => DeliveryInfo(
+  factory DeliveryInfo.empty() => DeliveryInfo(
       recInfo: ReceiverInfo.defaultReceiverInfo(),
+      arrivalDateAndTime: DateTime.now(),
+      compromisedAnimals: [],
+      additionalWelfareConcerns: "");
+
+  DeliveryInfo withJustReceiverInfo() => DeliveryInfo(
+      recInfo: recInfo,
       arrivalDateAndTime: DateTime.now(),
       compromisedAnimals: [],
       additionalWelfareConcerns: "");

--- a/app/lib/core/models/feed_water_rest_info.dart
+++ b/app/lib/core/models/feed_water_rest_info.dart
@@ -18,7 +18,7 @@ class FeedWaterRestInfo {
 
   List<FeedWaterRestEvent> get fwrEvents => List.unmodifiable(_fwrEvents);
 
-  factory FeedWaterRestInfo.defaultFwrInfo() => FeedWaterRestInfo(
+  factory FeedWaterRestInfo.empty() => FeedWaterRestInfo(
       lastFwrDate: DateTime.now(),
       lastFwrLocation: Address.defaultAddress(),
       fwrEvents: []);

--- a/app/lib/core/models/loading_vehicle_info.dart
+++ b/app/lib/core/models/loading_vehicle_info.dart
@@ -19,7 +19,7 @@ class LoadingVehicleInfo {
       @required List<AnimalGroup> animalsLoaded})
       : _animalsLoaded = animalsLoaded;
 
-  factory LoadingVehicleInfo.defaultVehicleInfo() => LoadingVehicleInfo(
+  factory LoadingVehicleInfo.empty() => LoadingVehicleInfo(
       dateAndTimeLoaded: DateTime.now(),
       loadingArea: 0,
       loadingDensity: 0,

--- a/app/lib/core/models/shipper_info.dart
+++ b/app/lib/core/models/shipper_info.dart
@@ -20,7 +20,7 @@ class ShipperInfo {
       @required this.departureAddress,
       @required this.shipperContactInfo});
 
-  factory ShipperInfo.defaultShipperInfo() => ShipperInfo(
+  factory ShipperInfo.empty() => ShipperInfo(
       shipperName: "",
       shipperIsAnimalOwner: false,
       departureLocationId: "",

--- a/app/lib/core/models/transporter_info.dart
+++ b/app/lib/core/models/transporter_info.dart
@@ -39,7 +39,7 @@ class TransporterInfo {
 
   List<String> get driverNames => List.unmodifiable(_driverNames);
 
-  factory TransporterInfo.defaultTransporterInfo() => TransporterInfo(
+  factory TransporterInfo.empty() => TransporterInfo(
       companyName: "",
       companyAddress: Address.defaultAddress(),
       driverNames: [],

--- a/app/lib/core/services/database/database_interface.dart
+++ b/app/lib/core/services/database/database_interface.dart
@@ -14,7 +14,7 @@ abstract class DatabaseInterface {
 
   Stream<Transporter> getUpdatedTransporter(String userId);
 
-  Future<AnimalTransportRecord> setNewAtr(String userId);
+  Future<AnimalTransportRecord> setNewAtr(AnimalTransportRecord atr);
 
   Future<void> updateAtr(AnimalTransportRecord atr);
 

--- a/app/lib/core/services/database/database_service.dart
+++ b/app/lib/core/services/database/database_service.dart
@@ -25,8 +25,8 @@ class DatabaseService {
   Stream<Transporter> getUpdatedTransporter(String userId) =>
       interface.getUpdatedTransporter(userId);
 
-  Future<AnimalTransportRecord> saveNewAtr(String userId) async =>
-      interface.setNewAtr(userId);
+  Future<AnimalTransportRecord> saveNewAtr(AnimalTransportRecord atr) async =>
+      interface.setNewAtr(atr);
 
   Future<void> saveUpdatedAtr(AnimalTransportRecord atr) async =>
       interface.updateAtr(atr);

--- a/app/lib/core/services/database/firebase_database_interface.dart
+++ b/app/lib/core/services/database/firebase_database_interface.dart
@@ -41,7 +41,7 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
 
   @override
   Future<AnimalTransportRecord> setNewAtr(String userId) async {
-    final defaultAtrAsPlaceholder = AnimalTransportRecord.defaultAtr(userId);
+    final defaultAtrAsPlaceholder = AnimalTransportRecord.empty(userId);
     return _firestore
         .collection('atr')
         .add(defaultAtrAsPlaceholder.toJSON())

--- a/app/lib/core/services/database/firebase_database_interface.dart
+++ b/app/lib/core/services/database/firebase_database_interface.dart
@@ -40,12 +40,11 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
           (DocumentSnapshot snapshot) => Transporter.fromJSON(snapshot.data()));
 
   @override
-  Future<AnimalTransportRecord> setNewAtr(String userId) async {
-    final defaultAtrAsPlaceholder = AnimalTransportRecord.empty(userId);
+  Future<AnimalTransportRecord> setNewAtr(AnimalTransportRecord atr) async {
     return _firestore
         .collection('atr')
-        .add(defaultAtrAsPlaceholder.toJSON())
-        .then((docRef) => defaultAtrAsPlaceholder.withDocId(docRef.id));
+        .add(atr.toJSON())
+        .then((docRef) => atr.withDocId(docRef.id));
   }
 
   @override

--- a/app/lib/core/services/service_locator.dart
+++ b/app/lib/core/services/service_locator.dart
@@ -4,6 +4,7 @@ import 'package:app/core/services/database/database_service.dart';
 import 'package:app/core/services/database/firebase_database_interface.dart';
 import 'package:app/core/services/dialog_service.dart';
 import 'package:app/core/services/nav_service.dart';
+import 'package:app/core/services/shared_preferences_service.dart';
 import 'package:app/core/services/validation_service.dart';
 import 'package:app/core/view_models/account_edit_view_model.dart';
 import 'package:app/core/view_models/account_screen_view_model.dart';
@@ -19,10 +20,13 @@ import 'package:app/core/view_models/welcome_screen_view_model.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:get_it/get_it.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 final locator = GetIt.instance;
 
-void setUpLocator() {
+void setUpLocator() async {
+  final sharedPreferencesInstance = await SharedPreferences.getInstance();
+
   // Singletons
   locator.registerLazySingleton<DatabaseInterface>(
       () => FirebaseDatabaseInterface(FirebaseFirestore.instance));
@@ -33,6 +37,8 @@ void setUpLocator() {
   locator.registerLazySingleton<NavigationService>(() => NavigationService());
   locator.registerLazySingleton<DialogService>(() => DialogService());
   locator.registerLazySingleton<ValidationService>(() => ValidationService());
+  locator.registerLazySingleton<SharedPreferencesService>(
+      () => SharedPreferencesService(sharedPreferencesInstance));
 
   // Factories
   locator.registerFactory<SplashScreenViewModel>(() => SplashScreenViewModel());

--- a/app/lib/core/services/shared_preferences_service.dart
+++ b/app/lib/core/services/shared_preferences_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:app/core/models/animal_transport_record.dart';
 import 'package:app/core/utilities/optional.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// A service wrapping the device's Shared Preferences
@@ -16,15 +17,34 @@ class SharedPreferencesService {
   Optional<AnimalTransportRecord> getDefaultAtr() {
     try {
       final atrMaybe = AnimalTransportRecord.fromJSON(
-          jsonDecode(_sharedPreferences.getString("defaultAtr")),
+          jsonDecode(_sharedPreferences.getString("defaultAtr"),
+              reviver: _decodeDateTimeIfNeeded),
           // No ATR Document ID for default ATR, set one later
           "");
       return Optional.of(atrMaybe);
-    } catch (_) {
+    } catch (error) {
+      print(error);
       return Optional.empty();
     }
   }
 
   void setAtrAsDefault(AnimalTransportRecord atr) =>
-      _sharedPreferences.setString("defaultAtr", jsonEncode(atr.toJSON()));
+      _sharedPreferences.setString("defaultAtr",
+          jsonEncode(atr.toJSON(), toEncodable: _encodeDateTimeIfNeeded));
+
+  dynamic _decodeDateTimeIfNeeded(dynamic key, dynamic value) {
+    try {
+      // We decode for google's date format so we convert to that format
+      return Timestamp.fromDate(DateTime.parse(value));
+    } catch (_) {
+      return value;
+    }
+  }
+
+  dynamic _encodeDateTimeIfNeeded(dynamic item) {
+    if (item is DateTime) {
+      return item.toString();
+    }
+    return item;
+  }
 }

--- a/app/lib/core/services/shared_preferences_service.dart
+++ b/app/lib/core/services/shared_preferences_service.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+
+import 'package:app/core/models/animal_transport_record.dart';
+import 'package:app/core/utilities/optional.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// A service wrapping the device's Shared Preferences
+/// Data may be persisted to disk asynchronously, and there is no guarantee
+/// that writes will be persisted to disk after returning, so this plugin must
+/// not be used for storing critical data.
+class SharedPreferencesService {
+  final SharedPreferences _sharedPreferences;
+
+  SharedPreferencesService(this._sharedPreferences);
+
+  Optional<AnimalTransportRecord> getDefaultAtr() {
+    try {
+      final atrMaybe = AnimalTransportRecord.fromJSON(
+          jsonDecode(_sharedPreferences.getString("defaultAtr")),
+          // No ATR Document ID for default ATR, set one later
+          "");
+      return Optional.of(atrMaybe);
+    } catch (_) {
+      return Optional.empty();
+    }
+  }
+
+  void setAtrAsDefault(AnimalTransportRecord atr) =>
+      _sharedPreferences.setString("defaultAtr", jsonEncode(atr.toJSON()));
+}

--- a/app/lib/core/view_models/active_screen_view_model.dart
+++ b/app/lib/core/view_models/active_screen_view_model.dart
@@ -8,6 +8,7 @@ import 'package:app/core/services/database/database_service.dart';
 import 'package:app/core/services/dialog_service.dart';
 import 'package:app/core/services/nav_service.dart';
 import 'package:app/core/services/service_locator.dart';
+import 'package:app/core/services/shared_preferences_service.dart';
 import 'package:app/core/utilities/optional.dart';
 import 'package:app/core/view_models/base_view_model.dart';
 import 'package:app/ui/common/view_state.dart';
@@ -22,6 +23,8 @@ import 'package:flutter/cupertino.dart';
 
 /// This ViewModel will only view active ATR models
 class ActiveScreenViewModel extends BaseViewModel {
+  final SharedPreferencesService _sharedPreferencesService =
+      locator<SharedPreferencesService>();
   final NavigationService _navigationService = locator<NavigationService>();
   final DatabaseService _databaseService = locator<DatabaseService>();
   final DialogService _dialogService = locator<DialogService>();
@@ -79,7 +82,7 @@ class ActiveScreenViewModel extends BaseViewModel {
     notifyListeners();
   }
 
-  // May have come from Home screen or Active screen
+// May have come from Home screen or Active screen
   void navigateBack() => _navigationService.pop();
 
   void navigateToHomeScreen() =>
@@ -95,8 +98,13 @@ class ActiveScreenViewModel extends BaseViewModel {
   Future<void> startNewAtr() async {
     setState(ViewState.Busy);
     final currentUser = _authenticationService.currentUser;
+    final defaultAtr = _sharedPreferencesService.getDefaultAtr();
     currentUser.isPresent()
-        ? _databaseService.saveNewAtr(currentUser.get().uid).then((atr) {
+        ? _databaseService
+            .saveNewAtr(defaultAtr.isPresent()
+                ? defaultAtr.get()
+                : AnimalTransportRecord.empty(currentUser.get().uid))
+            .then((atr) {
             setState(ViewState.Idle);
             return navigateToEditingScreen(atr);
           }).catchError((e) {

--- a/app/lib/core/view_models/home_screen_view_model.dart
+++ b/app/lib/core/view_models/home_screen_view_model.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
+
+import 'package:app/core/models/animal_transport_record.dart';
 import 'package:app/core/models/transporter.dart';
 import 'package:app/core/services/auth_service.dart';
 import 'package:app/core/services/database/database_service.dart';
 import 'package:app/core/services/dialog_service.dart';
 import 'package:app/core/services/nav_service.dart';
 import 'package:app/core/services/service_locator.dart';
+import 'package:app/core/services/shared_preferences_service.dart';
 import 'package:app/core/utilities/optional.dart';
 import 'package:app/core/view_models/base_view_model.dart';
 import 'package:app/ui/views/account/account_screen.dart';
@@ -16,6 +19,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 class HomeScreenViewModel extends BaseViewModel {
+  final SharedPreferencesService _sharedPreferencesService =
+      locator<SharedPreferencesService>();
   final DialogService _dialogService = locator<DialogService>();
   final DatabaseService _databaseService = locator<DatabaseService>();
   final AuthenticationService _authenticationService =
@@ -82,9 +87,12 @@ class HomeScreenViewModel extends BaseViewModel {
 
   Future<void> startNewAtr() async {
     final currentUser = _authenticationService.currentUser;
+    final defaultAtr = _sharedPreferencesService.getDefaultAtr();
     currentUser.isPresent()
         ? _databaseService
-            .saveNewAtr(currentUser.get().uid)
+            .saveNewAtr(defaultAtr.isPresent()
+                ? defaultAtr.get()
+                : AnimalTransportRecord.empty(currentUser.get().uid))
             .then((atr) => _navigationService.navigateTo(ATREditingScreen.route,
                 arguments: atr))
             .catchError((e) => _dialogService.showDialog(

--- a/app/lib/core/view_models/home_screen_view_model.dart
+++ b/app/lib/core/view_models/home_screen_view_model.dart
@@ -78,6 +78,7 @@ class HomeScreenViewModel extends BaseViewModel {
   void signOut() async {
     _authenticationService
         .signOut()
+        .then((_) => _sharedPreferencesService.unsetDefaultAtr())
         .then((_) => _navigationService.navigateAndReplace(WelcomeScreen.route))
         .catchError((error) => _dialogService.showDialog(
               title: 'Sign out failed',

--- a/app/lib/core/view_models/sign_in_view_model.dart
+++ b/app/lib/core/view_models/sign_in_view_model.dart
@@ -30,15 +30,22 @@ class SignInViewModel extends BaseViewModel {
     @required String password,
   }) async {
     setState(ViewState.Busy);
-    _authenticationService.signIn(email: email, password: password).then((_) {
-      _navigationService.navigateTo(HomeScreen.route);
-      setState(ViewState.Idle);
-    }).catchError((error) {
-      setState(ViewState.Idle);
-      _dialogService.showDialog(
-        title: 'Sign in failed',
-        description: error.message,
-      );
-    });
+    _authenticationService
+        .signIn(email: email, password: password)
+        .then((_) {
+          _navigationService.navigateTo(HomeScreen.route);
+          setState(ViewState.Idle);
+        })
+        .then((_) => _dialogService.showDialog(
+            title: "Welcome back!",
+            description:
+                "Please consider setting your default ATR in either the Active or Travel History screens"))
+        .catchError((error) {
+          setState(ViewState.Idle);
+          _dialogService.showDialog(
+            title: 'Sign in failed',
+            description: error.message,
+          );
+        });
   }
 }

--- a/app/lib/ui/common/style.dart
+++ b/app/lib/ui/common/style.dart
@@ -13,6 +13,7 @@ const White = Colors.white;
 const Beige = Color.fromRGBO(191, 186, 159, 1);
 const DarkerBeige = Color.fromRGBO(170, 160, 130, 1);
 const SlateGrey = Color.fromRGBO(134, 151, 166, 1);
+const SlateGreyOpaque = Color.fromRGBO(134, 151, 166, 200);
 const AlmostBlack = Color(0xFF212121);
 const OverlayColor = Color.fromRGBO(0, 0, 0, 0.5);
 

--- a/app/lib/ui/views/active/active_screen.dart
+++ b/app/lib/ui/views/active/active_screen.dart
@@ -91,7 +91,7 @@ class _ActiveScreenState extends State<ActiveScreen> {
                       createPreview(model, model.animalTransportRecords[index]),
                   gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
                       maxCrossAxisExtent: 200,
-                      childAspectRatio: 3 / 2,
+                      childAspectRatio: 9 / 8,
                       crossAxisSpacing: 20,
                       mainAxisSpacing: 20),
                 ),

--- a/app/lib/ui/views/history/history_screen.dart
+++ b/app/lib/ui/views/history/history_screen.dart
@@ -75,7 +75,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
                       createPreview(model, model.animalTransportRecords[index]),
                   gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
                       maxCrossAxisExtent: 200,
-                      childAspectRatio: 3 / 2,
+                      childAspectRatio: 9 / 8,
                       crossAxisSpacing: 20,
                       mainAxisSpacing: 20),
                 )),

--- a/app/lib/ui/widgets/atr_preview_card.dart
+++ b/app/lib/ui/widgets/atr_preview_card.dart
@@ -1,9 +1,17 @@
 import 'package:app/core/models/animal_transport_record.dart';
+import 'package:app/core/services/service_locator.dart';
+import 'package:app/core/services/shared_preferences_service.dart';
 import 'package:app/ui/common/style.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class ATRPreviewCard extends StatefulWidget {
+  // TODO: Move this into business logic somehow
+  // Unfortunately it needs to stay here as the set as default is common
+  // to all preview cards
+  final SharedPreferencesService _sharedPreferencesService =
+      locator<SharedPreferencesService>();
   final AnimalTransportRecord atr;
 
   final GestureTapCallback onTap;
@@ -18,30 +26,42 @@ class ATRPreviewCard extends StatefulWidget {
 class _AtrPreviewState extends State<ATRPreviewCard> {
   @override
   Widget build(BuildContext context) {
-    return Card(
-        child: GridTile(
-            child: Column(
-      children: [
-        Icon(
-          Icons.folder,
-          color: NavyBlue,
-          size: 40,
-        ),
-        ListTile(
-          title: Text(
-            'Transport for ${widget.atr.deliveryInfo.recInfo.receiverCompanyName}',
-            textAlign: TextAlign.center,
-            style: TextStyle(fontSize: BodyTextSize),
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-          ),
-          subtitle: Text(
-            '${DateFormat("yyyy-MM-dd hh:mm").format(widget.atr.vehicleInfo.dateAndTimeLoaded)}',
-            textAlign: TextAlign.center,
-          ),
-          onTap: widget.onTap,
-        )
-      ],
-    )));
+    return Container(
+        height: double.infinity,
+        child: Card(
+            child: GridTile(
+                child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.folder,
+              color: NavyBlue,
+              size: 50,
+            ),
+            ListTile(
+              title: Text(
+                'Transport for ${widget.atr.deliveryInfo.recInfo.receiverCompanyName}',
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: BodyTextSize),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              subtitle: Text(
+                '${DateFormat("yyyy-MM-dd hh:mm").format(widget.atr.vehicleInfo.dateAndTimeLoaded)}',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.only(bottom: 20.0),
+            ),
+            RaisedButton(
+              onPressed: () => widget._sharedPreferencesService
+                  .setAtrAsDefault(widget.atr.asDefault()),
+              child: Text('Set as default',
+                  style: TextStyle(fontSize: 20, color: Colors.white)),
+              color: NavyBlue,
+            )
+          ],
+        ))));
   }
 }

--- a/app/lib/ui/widgets/atr_preview_card.dart
+++ b/app/lib/ui/widgets/atr_preview_card.dart
@@ -26,42 +26,36 @@ class ATRPreviewCard extends StatefulWidget {
 class _AtrPreviewState extends State<ATRPreviewCard> {
   @override
   Widget build(BuildContext context) {
-    return Container(
-        height: double.infinity,
-        child: Card(
-            child: GridTile(
-                child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.folder,
-              color: NavyBlue,
-              size: 50,
-            ),
-            ListTile(
-              title: Text(
-                'Transport for ${widget.atr.deliveryInfo.recInfo.receiverCompanyName}',
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: BodyTextSize),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-              subtitle: Text(
-                '${DateFormat("yyyy-MM-dd hh:mm").format(widget.atr.vehicleInfo.dateAndTimeLoaded)}',
-                textAlign: TextAlign.center,
-              ),
-            ),
-            Padding(
-              padding: EdgeInsets.only(bottom: 20.0),
-            ),
-            RaisedButton(
-              onPressed: () => widget._sharedPreferencesService
-                  .setAtrAsDefault(widget.atr.asDefault()),
-              child: Text('Set as default',
-                  style: TextStyle(fontSize: 20, color: Colors.white)),
-              color: NavyBlue,
-            )
-          ],
-        ))));
+    return Card(
+        child: GridTile(
+            child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconButton(
+          icon: Icon(Icons.folder),
+          color: NavyBlue,
+          iconSize: 50,
+          onPressed: widget.onTap,
+        ),
+        Text(
+          'Transport for ${widget.atr.deliveryInfo.recInfo.receiverCompanyName}',
+          textAlign: TextAlign.center,
+          style: TextStyle(fontSize: BodyTextSize),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        Text(
+          '${DateFormat("yyyy-MM-dd hh:mm").format(widget.atr.vehicleInfo.dateAndTimeLoaded)}',
+          textAlign: TextAlign.center,
+        ),
+        RaisedButton(
+          onPressed: () => widget._sharedPreferencesService
+              .setAtrAsDefault(widget.atr.asDefault()),
+          child:
+              Text('Set as my default', style: TextStyle(color: Colors.white)),
+          color: SlateGreyOpaque,
+        )
+      ],
+    )));
   }
 }

--- a/app/lib/ui/widgets/atr_preview_card.dart
+++ b/app/lib/ui/widgets/atr_preview_card.dart
@@ -8,8 +8,8 @@ import 'package:intl/intl.dart';
 
 class ATRPreviewCard extends StatefulWidget {
   // TODO: Move this into business logic somehow
-  // Unfortunately it needs to stay here as the set as default is common
-  // to all preview cards
+  // Unfortunately it needs to stay here for now as the set as default
+  // is common to all preview cards
   final SharedPreferencesService _sharedPreferencesService =
       locator<SharedPreferencesService>();
   final AnimalTransportRecord atr;

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -487,7 +487,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.27"
+    version: "1.6.28"
   path_provider_linux:
     dependency: transitive
     description:
@@ -600,6 +600,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.12+4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.2+4"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+11"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2+7"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.2+3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -619,20 +661,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0-nullsafety.2"
-  sqflite:
-    dependency: "direct main"
-    description:
-      name: sqflite
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.2+4"
-  sqflite_common:
-    dependency: transitive
-    description:
-      name: sqflite_common
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.3+1"
   stack_trace:
     dependency: transitive
     description:
@@ -661,13 +689,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
-  synchronized:
-    dependency: transitive
-    description:
-      name: synchronized
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.0+2"
   term_glyph:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   pdf: ^2.0.0
   permission_handler: ^5.0.1+1
   provider: ^4.3.2+3
-  sqflite: ^1.3.2+2
+  shared_preferences: ^0.5.12+4
   uuid: 2.2.2
   google_fonts: ^1.1.2
   network_image_to_byte: ^0.0.1

--- a/app/test/core/services/database/database_service_test.dart
+++ b/app/test/core/services/database/database_service_test.dart
@@ -5,6 +5,7 @@ import 'package:app/core/services/database/database_interface.dart';
 import 'package:app/core/services/database/database_service.dart';
 import 'package:app/core/services/database/firebase_database_interface.dart';
 import 'package:app/test/mock/test_mocks_for_firebase.dart';
+import 'package:app/test/test_data.dart';
 import 'package:app/test/test_json.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -78,12 +79,12 @@ void main() {
       verify(mockDocumentReference.delete()).called(1);
     });
 
-    test('Should set new default ATR to firestore', () async {
+    test('Should set new ATR to firestore', () async {
       when(mockFirestoreInstance.collection('atr'))
           .thenReturn(mockCollectionReference);
       when(mockCollectionReference.add(any))
           .thenAnswer((_) async => mockDocumentReference);
-      await dbService.saveNewAtr("test ID");
+      await dbService.saveNewAtr(testAnimalTransportRecord());
       verify(mockCollectionReference.add(any)).called(1);
     });
 

--- a/app/test/ui/views/active/atr_editing_screen_test.dart
+++ b/app/test/ui/views/active/atr_editing_screen_test.dart
@@ -201,7 +201,7 @@ void main() {
 
     testWidgets('invalid form blocks completion submission',
         (WidgetTester tester) async {
-      final invalidAtr = AnimalTransportRecord.defaultAtr("testId");
+      final invalidAtr = AnimalTransportRecord.empty("testId");
       final submitButtonFinder = find.text("Submit");
 
       await pumpATREditingScreen(tester, invalidAtr);

--- a/app/test/ui/widgets/atr_preview_card_test.dart
+++ b/app/test/ui/widgets/atr_preview_card_test.dart
@@ -1,11 +1,26 @@
+import 'package:app/core/services/shared_preferences_service.dart';
 import 'package:app/test/test_data.dart';
 import 'package:app/ui/widgets/atr_preview_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
 import 'package:intl/intl.dart';
+import 'package:mockito/mockito.dart';
+
+class MockSharedPreferencesService extends Mock
+    implements SharedPreferencesService {}
+
+final testLocator = GetIt.instance;
 
 void main() {
+  final mockSharedPreferencesService = MockSharedPreferencesService();
+
   group('ATR Preview Card', () {
+    setUpAll(() async {
+      testLocator.registerLazySingleton<SharedPreferencesService>(
+          () => mockSharedPreferencesService);
+    });
+
     testWidgets('shows right information', (WidgetTester tester) async {
       final testDate = DateTime.parse("2021-01-01 01:01");
       final testCompany = "Test Company";
@@ -41,9 +56,26 @@ void main() {
         onTap: testCallback,
       );
       await tester.pumpWidget(new MaterialApp(home: widget));
-      await tester.tap(find.text("Transport for $testCompany"));
+      await tester.tap(find.byIcon(Icons.folder));
       await tester.pumpAndSettle();
       expect(callback, true);
+    });
+
+    testWidgets('calls set as default on tap', (WidgetTester tester) async {
+      final testCompany = "Test Company";
+      final testRecWithDelInfo = testAnimalTransportRecord().withDeliveryInfo(
+          testDeliveryInfo(
+              recInfo: testReceiverInfo(receiverCompanyName: testCompany)));
+      final widget = ATRPreviewCard(
+        atr: testRecWithDelInfo,
+        onTap: () {
+          // do nothing for test
+        },
+      );
+      await tester.pumpWidget(new MaterialApp(home: widget));
+      await tester.tap(find.text("Set as my default"));
+      await tester.pumpAndSettle();
+      verify(mockSharedPreferencesService.setAtrAsDefault(any)).called(1);
     });
   });
 }


### PR DESCRIPTION
Closes #211 .

In this PR I have:
1. Added a button to set your default ATR. This can be clicked again if misclicked.
2. Made the `SharedPreferencesService` for shared preferences use
> About shared preferences... the data exists until the app is deleted or cache cleared (when updating). So, on sign out we have to clear it manually.
3. I added notifications to use the default ATR because people might forget
4. I updated unit tests accordingly

The information kept for the default ATR does not include:
1. FWR info
2. Loading information
3. Contingency event information

**These are different between transports, so the transporter should input new information each time.**

***

Changes look like:


https://user-images.githubusercontent.com/32527219/112397238-4f322900-8cc7-11eb-8514-20455914b4ed.mp4


https://user-images.githubusercontent.com/32527219/112397243-535e4680-8cc7-11eb-8c49-3d3d754fecad.mp4

