### PR TITLE
Add missing admin read all history records

### DIFF
--- a/app/lib/core/services/database/database_interface.dart
+++ b/app/lib/core/services/database/database_interface.dart
@@ -32,5 +32,7 @@ abstract class DatabaseInterface {
 
   Stream<List<AnimalTransportRecord>> getUpdatedCompleteATRs(String userId);
 
+  Stream<List<AnimalTransportRecord>> getAllUpdatedCompleteATRs();
+
   Stream<List<AnimalTransportRecord>> getUpdatedActiveATRs(String userId);
 }

--- a/app/lib/core/services/database/database_service.dart
+++ b/app/lib/core/services/database/database_service.dart
@@ -42,6 +42,9 @@ class DatabaseService {
   Stream<List<AnimalTransportRecord>> getUpdatedCompleteATRs(String userId) =>
       interface.getUpdatedCompleteATRs(userId);
 
+  Stream<List<AnimalTransportRecord>> getAllUpdatedCompleteATRs() =>
+      interface.getAllUpdatedCompleteATRs();
+
   Stream<List<AnimalTransportRecord>> getUpdatedActiveATRs(String userId) =>
       interface.getUpdatedActiveATRs(userId);
 

--- a/app/lib/core/services/database/firebase_database_interface.dart
+++ b/app/lib/core/services/database/firebase_database_interface.dart
@@ -79,7 +79,6 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
               .map((doc) => AnimalTransportRecord.fromJSON(doc.data(), doc.id))
               .toList());
 
-  /// This returns the whole list of records in the database, not just updated ones
   @override
   Stream<List<AnimalTransportRecord>> getUpdatedCompleteATRs(String userId) =>
       _firestore
@@ -91,7 +90,15 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
               .map((doc) => AnimalTransportRecord.fromJSON(doc.data(), doc.id))
               .toList());
 
-  /// This returns the whole list of records in the database, not just updated ones
+  @override
+  Stream<List<AnimalTransportRecord>> getAllUpdatedCompleteATRs() => _firestore
+      .collection('atr')
+      .where('identifier.isComplete', isEqualTo: true)
+      .snapshots()
+      .map((snapshot) => snapshot.docs
+          .map((doc) => AnimalTransportRecord.fromJSON(doc.data(), doc.id))
+          .toList());
+
   @override
   Stream<List<AnimalTransportRecord>> getUpdatedActiveATRs(String userId) =>
       _firestore

--- a/app/lib/core/view_models/sign_in_view_model.dart
+++ b/app/lib/core/view_models/sign_in_view_model.dart
@@ -4,8 +4,8 @@ import 'package:app/core/services/nav_service.dart';
 import 'package:app/core/services/service_locator.dart';
 import 'package:app/core/view_models/base_view_model.dart';
 import 'package:app/ui/common/view_state.dart';
-import 'package:app/ui/views/reset_password/forgot_password_screen.dart';
 import 'package:app/ui/views/home_screen.dart';
+import 'package:app/ui/views/reset_password/forgot_password_screen.dart';
 import 'package:app/ui/views/sign_up_screen.dart';
 import 'package:app/ui/views/welcome_screen.dart';
 import 'package:flutter/material.dart';
@@ -33,7 +33,7 @@ class SignInViewModel extends BaseViewModel {
     _authenticationService
         .signIn(email: email, password: password)
         .then((_) {
-          _navigationService.navigateTo(HomeScreen.route);
+          _navigationService.navigateAndReplace(HomeScreen.route);
           setState(ViewState.Idle);
         })
         .then((_) => _dialogService.showDialog(

--- a/app/lib/core/view_models/welcome_screen_view_model.dart
+++ b/app/lib/core/view_models/welcome_screen_view_model.dart
@@ -8,8 +8,8 @@ class WelcomeScreenViewModel extends BaseViewModel {
   final NavigationService _navigationService = locator<NavigationService>();
 
   void navigateToSignInScreen() =>
-      _navigationService.navigateTo(SignInScreen.route);
+      _navigationService.navigateAndReplace(SignInScreen.route);
 
   void navigateToSignUpScreen() =>
-      _navigationService.navigateTo(SignUpScreen.route);
+      _navigationService.navigateAndReplace(SignUpScreen.route);
 }

--- a/app/lib/ui/views/account/account_screen.dart
+++ b/app/lib/ui/views/account/account_screen.dart
@@ -1,4 +1,5 @@
 import 'package:app/core/view_models/account_screen_view_model.dart';
+import 'package:app/ui/common/default_image.dart';
 import 'package:app/ui/common/style.dart';
 import 'package:app/ui/widgets/utility/setting_icon.dart';
 import 'package:app/ui/widgets/utility/template_base_view_model.dart';
@@ -35,14 +36,16 @@ class AccountScreen extends StatelessWidget {
                   child: Column(
                     children: [
                       ListTile(
-                        leading: Icon(
-                          Icons.account_circle_sharp,
-                          size: 30.0,
-                          color: NavyBlue,
-                        ),
+                        leading: CircleAvatar(
+                            radius: 35,
+                            backgroundColor: Colors.grey[300],
+                            backgroundImage:
+                                model.transporter.displayImageUrl.isNotEmpty
+                                    ? NetworkImage(
+                                        model.transporter.displayImageUrl)
+                                    : NetworkImage(defaultImage)),
                         title: Text(
                           '${model.transporter.firstName} ${model.transporter.lastName}',
-                          style: TextStyle(fontSize: 15.0),
                         ),
                         trailing: ElevatedButton(
                           onPressed: () =>
@@ -60,6 +63,21 @@ class AccountScreen extends StatelessWidget {
                         border:
                             TableBorder.all(color: Colors.black12, width: 2),
                         children: [
+                          if (model.transporter.isAdmin)
+                            TableRow(
+                                decoration: BoxDecoration(color: Beige),
+                                children: [
+                                  ListTile(
+                                    leading: Icon(
+                                      Icons.account_circle,
+                                      size: 30.0,
+                                      color: NavyBlue,
+                                    ),
+                                    title: Text(
+                                      'Administrator',
+                                    ),
+                                  ),
+                                ]),
                           TableRow(
                               decoration: BoxDecoration(color: Beige),
                               children: [
@@ -71,7 +89,6 @@ class AccountScreen extends StatelessWidget {
                                   ),
                                   title: Text(
                                     '${model.transporter.userPhoneNumber}',
-                                    style: TextStyle(fontSize: 15.0),
                                   ),
                                 ),
                               ]),
@@ -86,7 +103,6 @@ class AccountScreen extends StatelessWidget {
                                   ),
                                   title: Text(
                                     '${model.transporter.userEmailAddress} ',
-                                    style: TextStyle(fontSize: 15.0),
                                   ),
                                 ),
                               ])

--- a/app/lib/ui/views/home_screen.dart
+++ b/app/lib/ui/views/home_screen.dart
@@ -23,18 +23,27 @@ class HomeScreen extends StatelessWidget {
                   alignment: Alignment.center,
                   children: <Widget>[
                     Image.asset("assets/home_cover.jpg"),
-                    // TODO: #223. Use the logged in transporter's name
                     Positioned(
                       bottom: 20.0,
                       left: 10.0,
                       child: model.transporter != null
-                          ? Text(
-                              '${model.transporter.firstName} ${model.transporter.lastName} ',
-                              style: TextStyle(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: MediumTextSize),
-                            )
+                          ? Column(children: [
+                              if (model.transporter.isAdmin)
+                                Text(
+                                  'Administrator',
+                                  style: TextStyle(
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: MediumTextSize),
+                                ),
+                              Text(
+                                '${model.transporter.firstName} ${model.transporter.lastName}',
+                                style: TextStyle(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: MediumTextSize),
+                              )
+                            ])
                           : CircularProgressIndicator(
                               strokeWidth: 4,
                               valueColor: AlwaysStoppedAnimation(NavyBlue),

--- a/app/test/core/services/database/database_service_test.dart
+++ b/app/test/core/services/database/database_service_test.dart
@@ -238,5 +238,29 @@ void main() {
         expect(records, testRecords);
       }));
     });
+
+    test('Should get all completed ATRs stream', () async {
+      final testRecords = [
+        AnimalTransportRecord.fromJSON(testAtrJson(), "123")
+      ];
+      when(mockFirestoreInstance.collection('atr'))
+          .thenReturn(mockCollectionReference);
+      when(mockCollectionReference.where('identifier.isComplete',
+              isEqualTo: true))
+          .thenReturn(mockQuery);
+
+      // Mock stream and stream map return
+      Stream<List<AnimalTransportRecord>> myStream() async* {
+        yield [AnimalTransportRecord.fromJSON(testAtrJson(), "123")];
+      }
+
+      when(mockQuery.snapshots()).thenAnswer((_) => mockStream);
+      when(mockStream.map(any)).thenAnswer((_) => myStream());
+
+      final stream = dbService.getAllUpdatedCompleteATRs();
+      stream.listen(expectAsync1<void, List<AnimalTransportRecord>>((records) {
+        expect(records, testRecords);
+      }));
+    });
   });
 }

--- a/app/test/core/view_models/sign_in_view_model_test.dart
+++ b/app/test/core/view_models/sign_in_view_model_test.dart
@@ -37,7 +37,7 @@ void main() {
         email: userEmailAddress,
         password: password,
       )).thenAnswer((_) async => Future.value()); // successful return
-      when(mockNavigationService.navigateTo(any)).thenAnswer(
+      when(mockNavigationService.navigateAndReplace(any)).thenAnswer(
           (_) async => Future.value()); // ignore return for this test
 
       await SignInViewModel()
@@ -46,7 +46,7 @@ void main() {
         email: userEmailAddress,
         password: password,
       )).called(1);
-      verify(mockNavigationService.navigateTo(any)).called(1);
+      verify(mockNavigationService.navigateAndReplace(any)).called(1);
     });
 
     test('failed to Navigate to HomeScreen after SignIn', () async {
@@ -65,7 +65,8 @@ void main() {
         email: userEmailAddress,
         password: password,
       )).called(1);
-      verifyNever(mockNavigationService.navigateTo(mockHomeScreenRoute));
+      verifyNever(
+          mockNavigationService.navigateAndReplace(mockHomeScreenRoute));
       verify(mockDialogService.showDialog(
               title: "Sign in failed", description: anyNamed("description")))
           .called(1);


### PR DESCRIPTION
This PR adds:
1. Some signifiers for administration accounts, like the title
> We could take this farther with color, button changes sometime
2. Fixes a navigation bug where you could back out to the sign in screen, forcing you to login again
3. Adds the functions that lets administrators see everyone's transport history

***

Changes look like:


https://user-images.githubusercontent.com/32527219/112689906-8415bb80-8e40-11eb-92d7-bb5daf3d3a2e.mp4

https://user-images.githubusercontent.com/32527219/112689914-85df7f00-8e40-11eb-9b4a-431eb0fa7593.mp4

