### PR TITLE
Time limit calls over the internet so to warn Transporter when device is offline

### DIFF
--- a/app/lib/core/services/auth_service.dart
+++ b/app/lib/core/services/auth_service.dart
@@ -6,6 +6,7 @@ import 'package:app/core/services/service_locator.dart';
 import 'package:app/core/utilities/optional.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 /// A service wrapping FirebaseAuth
 /// Sign in persistence is guaranteed default as per
@@ -50,9 +51,10 @@ class AuthenticationService {
   Future<void> resetPassword({
     @required String userEmailAddress,
   }) async =>
-      firebaseAuth
-          .sendPasswordResetEmail(email: userEmailAddress)
-          .timeout(Duration(seconds: 10));
+      firebaseAuth.sendPasswordResetEmail(email: userEmailAddress).timeout(
+          Duration(seconds: 10),
+          onTimeout: () => Future.error(PlatformException(
+              message: "The connection timed out!", code: "FUTURE_TIMEOUT")));
 
   Future<void> signOut() async => firebaseAuth.signOut();
 
@@ -62,7 +64,10 @@ class AuthenticationService {
   }) async =>
       firebaseAuth
           .signInWithEmailAndPassword(email: email, password: password)
-          .timeout(Duration(seconds: 10));
+          .timeout(Duration(seconds: 10),
+              onTimeout: () => Future<UserCredential>.error(PlatformException(
+                  message: "The connection timed out!",
+                  code: "FUTURE_TIMEOUT")));
 
   Future<void> signUp({
     @required String firstName,
@@ -77,7 +82,10 @@ class AuthenticationService {
             email: userEmailAddress,
             password: password,
           )
-          .timeout(Duration(seconds: 10))
+          .timeout(Duration(seconds: 10),
+              onTimeout: () => Future.error(PlatformException(
+                  message: "The connection timed out!",
+                  code: "FUTURE_TIMEOUT")))
           .then((authResult) => databaseService.addTransporter(Transporter(
                 userId: authResult.user.uid,
                 firstName: firstName,

--- a/app/lib/core/services/auth_service.dart
+++ b/app/lib/core/services/auth_service.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 /// A service wrapping FirebaseAuth
 /// Sign in persistence is guaranteed default as per
 /// https://firebase.flutter.dev/docs/auth/usage/#persisting-authentication-state
+/// Timeout are added to every future to prevent locking when internet unavailable
 class AuthenticationService {
   final databaseService = locator<DatabaseService>();
   final FirebaseAuth firebaseAuth;
@@ -49,7 +50,9 @@ class AuthenticationService {
   Future<void> resetPassword({
     @required String userEmailAddress,
   }) async =>
-      firebaseAuth.sendPasswordResetEmail(email: userEmailAddress);
+      firebaseAuth
+          .sendPasswordResetEmail(email: userEmailAddress)
+          .timeout(Duration(seconds: 10));
 
   Future<void> signOut() async => firebaseAuth.signOut();
 
@@ -57,7 +60,9 @@ class AuthenticationService {
     @required String email,
     @required String password,
   }) async =>
-      firebaseAuth.signInWithEmailAndPassword(email: email, password: password);
+      firebaseAuth
+          .signInWithEmailAndPassword(email: email, password: password)
+          .timeout(Duration(seconds: 10));
 
   Future<void> signUp({
     @required String firstName,
@@ -72,6 +77,7 @@ class AuthenticationService {
             email: userEmailAddress,
             password: password,
           )
+          .timeout(Duration(seconds: 10))
           .then((authResult) => databaseService.addTransporter(Transporter(
                 userId: authResult.user.uid,
                 firstName: firstName,

--- a/app/lib/core/services/database/firebase_database_interface.dart
+++ b/app/lib/core/services/database/firebase_database_interface.dart
@@ -5,6 +5,7 @@ import 'package:app/core/models/animal_transport_record.dart';
 import 'package:app/core/models/transporter.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/services.dart';
 
 import 'database_interface.dart';
 
@@ -22,7 +23,9 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
       .collection('transporter')
       .doc(newTransporter.userId)
       .set(newTransporter.toJSON())
-      .timeout(Duration(seconds: 10));
+      .timeout(Duration(seconds: 10),
+          onTimeout: () => Future.error(PlatformException(
+              message: "The connection timed out!", code: "FUTURE_TIMEOUT")));
 
   @override
   Future<Transporter> getTransporter(String userId) async => _firestore
@@ -31,14 +34,18 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
       .get()
       .then(
           (DocumentSnapshot snapshot) => Transporter.fromJSON(snapshot.data()))
-      .timeout(Duration(seconds: 10));
+      .timeout(Duration(seconds: 10),
+          onTimeout: () => Future.error(PlatformException(
+              message: "The connection timed out!", code: "FUTURE_TIMEOUT")));
 
   @override
   Future<void> updateTransporter(Transporter transporter) => _firestore
       .collection('transporter')
       .doc(transporter.userId)
       .update(transporter.toJSON())
-      .timeout(Duration(seconds: 10));
+      .timeout(Duration(seconds: 10),
+          onTimeout: () => Future.error(PlatformException(
+              message: "The connection timed out!", code: "FUTURE_TIMEOUT")));
 
   @override
   Future<void> removeTransporter(String userId) async =>
@@ -55,7 +62,9 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
         .collection('atr')
         .add(atr.toJSON())
         .then((docRef) => atr.withDocId(docRef.id))
-        .timeout(Duration(seconds: 10));
+        .timeout(Duration(seconds: 10),
+            onTimeout: () => Future.error(PlatformException(
+                message: "The connection timed out!", code: "FUTURE_TIMEOUT")));
   }
 
   @override
@@ -63,14 +72,18 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
       .collection('atr')
       .doc(atr.identifier.atrDocumentId)
       .update(atr.toJSON())
-      .timeout(Duration(seconds: 10));
+      .timeout(Duration(seconds: 10),
+          onTimeout: () => Future.error(PlatformException(
+              message: "The connection timed out!", code: "FUTURE_TIMEOUT")));
 
   @override
   Future<void> removeAtr(String atrDocumentId) async => _firestore
       .collection('atr')
       .doc(atrDocumentId)
       .delete()
-      .timeout(Duration(seconds: 10));
+      .timeout(Duration(seconds: 10),
+          onTimeout: () => Future.error(PlatformException(
+              message: "The connection timed out!", code: "FUTURE_TIMEOUT")));
 
   @override
   Future<List<AnimalTransportRecord>> getCompleteRecords(String userId) async =>
@@ -82,7 +95,10 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
           .then((snapshot) => snapshot.docs
               .map((doc) => AnimalTransportRecord.fromJSON(doc.data(), doc.id))
               .toList())
-          .timeout(Duration(seconds: 10));
+          .timeout(Duration(seconds: 10),
+              onTimeout: () => Future.error(PlatformException(
+                  message: "The connection timed out!",
+                  code: "FUTURE_TIMEOUT")));
 
   @override
   Future<List<AnimalTransportRecord>> getActiveRecords(String userId) async =>
@@ -94,7 +110,10 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
           .then((snapshot) => snapshot.docs
               .map((doc) => AnimalTransportRecord.fromJSON(doc.data(), doc.id))
               .toList())
-          .timeout(Duration(seconds: 10));
+          .timeout(Duration(seconds: 10),
+              onTimeout: () => Future.error(PlatformException(
+                  message: "The connection timed out!",
+                  code: "FUTURE_TIMEOUT")));
 
   @override
   Stream<List<AnimalTransportRecord>> getUpdatedCompleteATRs(String userId) =>
@@ -134,7 +153,10 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
           .child('atrImages/$fileName')
           .putFile(file)
           .then((TaskSnapshot snapshot) => snapshot.ref.getDownloadURL())
-          .timeout(Duration(seconds: 10));
+          .timeout(Duration(seconds: 10),
+              onTimeout: () => Future.error(PlatformException(
+                  message: "The connection timed out!",
+                  code: "FUTURE_TIMEOUT")));
 
   @override
   Future<String> uploadAvatarImage(File file, String fileName) async =>
@@ -143,12 +165,17 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
           .child('avatarImages/$fileName')
           .putFile(file)
           .then((TaskSnapshot snapshot) => snapshot.ref.getDownloadURL())
-          .timeout(Duration(seconds: 10));
+          .timeout(Duration(seconds: 10),
+              onTimeout: () => Future.error(PlatformException(
+                  message: "The connection timed out!",
+                  code: "FUTURE_TIMEOUT")));
 
   @override
   Future<String> getAtrImage(String fileName) async => FirebaseStorage.instance
       .ref()
       .child('atrImages/$fileName')
       .getDownloadURL()
-      .timeout(Duration(seconds: 10));
+      .timeout(Duration(seconds: 10),
+          onTimeout: () => Future.error(PlatformException(
+              message: "The connection timed out!", code: "FUTURE_TIMEOUT")));
 }

--- a/app/lib/core/services/database/firebase_database_interface.dart
+++ b/app/lib/core/services/database/firebase_database_interface.dart
@@ -8,6 +8,10 @@ import 'package:firebase_storage/firebase_storage.dart';
 
 import 'database_interface.dart';
 
+/// The interface for FirebaseFirestore
+/// All Future calls contain a timeout as per https://stackoverflow.com/a/53551036
+/// (We could go without futures as suggested, but that seems antipattern
+/// because we would like to be notified of permission errors and the like)
 class FirebaseDatabaseInterface implements DatabaseInterface {
   final FirebaseFirestore _firestore;
 
@@ -17,18 +21,24 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
   Future<void> setNewTransporter(Transporter newTransporter) async => _firestore
       .collection('transporter')
       .doc(newTransporter.userId)
-      .set(newTransporter.toJSON());
+      .set(newTransporter.toJSON())
+      .timeout(Duration(seconds: 10));
 
   @override
-  Future<Transporter> getTransporter(String userId) async =>
-      _firestore.collection('transporter').doc(userId).get().then(
-          (DocumentSnapshot snapshot) => Transporter.fromJSON(snapshot.data()));
+  Future<Transporter> getTransporter(String userId) async => _firestore
+      .collection('transporter')
+      .doc(userId)
+      .get()
+      .then(
+          (DocumentSnapshot snapshot) => Transporter.fromJSON(snapshot.data()))
+      .timeout(Duration(seconds: 10));
 
   @override
   Future<void> updateTransporter(Transporter transporter) => _firestore
       .collection('transporter')
       .doc(transporter.userId)
-      .update(transporter.toJSON());
+      .update(transporter.toJSON())
+      .timeout(Duration(seconds: 10));
 
   @override
   Future<void> removeTransporter(String userId) async =>
@@ -44,18 +54,23 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
     return _firestore
         .collection('atr')
         .add(atr.toJSON())
-        .then((docRef) => atr.withDocId(docRef.id));
+        .then((docRef) => atr.withDocId(docRef.id))
+        .timeout(Duration(seconds: 10));
   }
 
   @override
   Future<void> updateAtr(AnimalTransportRecord atr) async => _firestore
       .collection('atr')
       .doc(atr.identifier.atrDocumentId)
-      .update(atr.toJSON());
+      .update(atr.toJSON())
+      .timeout(Duration(seconds: 10));
 
   @override
-  Future<void> removeAtr(String atrDocumentId) async =>
-      _firestore.collection('atr').doc(atrDocumentId).delete();
+  Future<void> removeAtr(String atrDocumentId) async => _firestore
+      .collection('atr')
+      .doc(atrDocumentId)
+      .delete()
+      .timeout(Duration(seconds: 10));
 
   @override
   Future<List<AnimalTransportRecord>> getCompleteRecords(String userId) async =>
@@ -66,7 +81,8 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
           .get()
           .then((snapshot) => snapshot.docs
               .map((doc) => AnimalTransportRecord.fromJSON(doc.data(), doc.id))
-              .toList());
+              .toList())
+          .timeout(Duration(seconds: 10));
 
   @override
   Future<List<AnimalTransportRecord>> getActiveRecords(String userId) async =>
@@ -77,7 +93,8 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
           .get()
           .then((snapshot) => snapshot.docs
               .map((doc) => AnimalTransportRecord.fromJSON(doc.data(), doc.id))
-              .toList());
+              .toList())
+          .timeout(Duration(seconds: 10));
 
   @override
   Stream<List<AnimalTransportRecord>> getUpdatedCompleteATRs(String userId) =>
@@ -116,7 +133,8 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
           .ref()
           .child('atrImages/$fileName')
           .putFile(file)
-          .then((TaskSnapshot snapshot) => snapshot.ref.getDownloadURL());
+          .then((TaskSnapshot snapshot) => snapshot.ref.getDownloadURL())
+          .timeout(Duration(seconds: 10));
 
   @override
   Future<String> uploadAvatarImage(File file, String fileName) async =>
@@ -124,11 +142,13 @@ class FirebaseDatabaseInterface implements DatabaseInterface {
           .ref()
           .child('avatarImages/$fileName')
           .putFile(file)
-          .then((TaskSnapshot snapshot) => snapshot.ref.getDownloadURL());
+          .then((TaskSnapshot snapshot) => snapshot.ref.getDownloadURL())
+          .timeout(Duration(seconds: 10));
 
   @override
   Future<String> getAtrImage(String fileName) async => FirebaseStorage.instance
       .ref()
       .child('atrImages/$fileName')
-      .getDownloadURL();
+      .getDownloadURL()
+      .timeout(Duration(seconds: 10));
 }

--- a/app/lib/core/view_models/account_edit_view_model.dart
+++ b/app/lib/core/view_models/account_edit_view_model.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:app/core/models/transporter.dart';
 import 'package:app/core/services/database/database_service.dart';
 import 'package:app/core/services/dialog_service.dart';
@@ -19,8 +20,10 @@ class AccountEditViewModel extends BaseViewModel {
 
   Transporter _account;
   File _selectedImage;
+
   File get selectedImage => _selectedImage;
   String _imageUrl;
+
   String get imageUrl => _imageUrl;
 
   Future<void> selectImage() async {
@@ -54,7 +57,6 @@ class AccountEditViewModel extends BaseViewModel {
     @required String userPhoneNumber,
   }) async {
     setState(ViewState.Busy);
-
     setImageUrl().then((value) {
       var updateTransporterAccount = Transporter(
         firstName: firstName,

--- a/app/lib/core/view_models/forgot_password_view_model.dart
+++ b/app/lib/core/view_models/forgot_password_view_model.dart
@@ -27,7 +27,7 @@ class ForgotPasswordViewModel extends BaseViewModel {
     }).catchError((error) {
       setState(ViewState.Idle);
       _dialogService.showDialog(
-        title: 'Reset Password failed',
+        title: 'Reset password failed',
         description: error.message,
       );
     });

--- a/app/lib/core/view_models/home_screen_view_model.dart
+++ b/app/lib/core/view_models/home_screen_view_model.dart
@@ -10,6 +10,7 @@ import 'package:app/core/services/service_locator.dart';
 import 'package:app/core/services/shared_preferences_service.dart';
 import 'package:app/core/utilities/optional.dart';
 import 'package:app/core/view_models/base_view_model.dart';
+import 'package:app/ui/common/view_state.dart';
 import 'package:app/ui/views/account/account_screen.dart';
 import 'package:app/ui/views/active/active_screen.dart';
 import 'package:app/ui/views/active/atr_editing_screen.dart';
@@ -87,6 +88,7 @@ class HomeScreenViewModel extends BaseViewModel {
   }
 
   Future<void> startNewAtr() async {
+    setState(ViewState.Busy);
     final currentUser = _authenticationService.currentUser;
     final defaultAtr = _sharedPreferencesService.getDefaultAtr();
     currentUser.isPresent()
@@ -94,12 +96,16 @@ class HomeScreenViewModel extends BaseViewModel {
             .saveNewAtr(defaultAtr.isPresent()
                 ? defaultAtr.get()
                 : AnimalTransportRecord.empty(currentUser.get().uid))
-            .then((atr) => _navigationService.navigateTo(ATREditingScreen.route,
-                arguments: atr))
-            .catchError((e) => _dialogService.showDialog(
-                  title: 'Starting a new Animal Transport Record failed',
-                  description: e.message,
-                ))
+            .then((atr) {
+            setState(ViewState.Idle);
+            return _navigationService.navigateTo(ATREditingScreen.route);
+          }).catchError((e) {
+            setState(ViewState.Idle);
+            _dialogService.showDialog(
+              title: 'Starting a new Animal Transport Record failed',
+              description: e.message,
+            );
+          })
         : _dialogService.showDialog(
             title: 'Starting a new Animal Transport Record failed',
             description: "You are not logged in!",

--- a/app/lib/core/view_models/signup_view_model.dart
+++ b/app/lib/core/view_models/signup_view_model.dart
@@ -16,6 +16,7 @@ class SignUpViewModel extends BaseViewModel {
   final NavigationService _navigationService = locator<NavigationService>();
 
   String _imageUrl;
+
   String get imageUrl => _imageUrl;
 
   void navigateToWelcomeScreen() =>

--- a/app/lib/ui/views/home_screen.dart
+++ b/app/lib/ui/views/home_screen.dart
@@ -1,6 +1,8 @@
 import 'package:app/core/view_models/home_screen_view_model.dart';
 import 'package:app/ui/common/default_image.dart';
 import 'package:app/ui/common/style.dart';
+import 'package:app/ui/common/view_state.dart';
+import 'package:app/ui/widgets/utility/busy_overlay_screen.dart';
 import 'package:app/ui/widgets/utility/template_base_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -10,173 +12,177 @@ class HomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Beige,
-      appBar: appBarInner('Home Screen'),
-      body: Center(
-        child: TemplateBaseViewModel<HomeScreenViewModel>(
-          onModelReady: (model) => model.loadTransporterInfo(),
-          builder: (context, model, child) => SingleChildScrollView(
-            child: Column(
-              children: <Widget>[
-                Stack(
-                  alignment: Alignment.center,
-                  children: <Widget>[
-                    Image.asset("assets/home_cover.jpg"),
-                    Positioned(
-                      bottom: 20.0,
-                      left: 10.0,
-                      child: model.transporter != null
-                          ? Column(children: [
-                              if (model.transporter.isAdmin)
-                                Text(
-                                  'Administrator',
-                                  style: TextStyle(
-                                      color: Colors.white,
-                                      fontWeight: FontWeight.bold,
-                                      fontSize: MediumTextSize),
-                                ),
-                              Text(
-                                '${model.transporter.firstName} ${model.transporter.lastName}',
-                                style: TextStyle(
-                                    color: Colors.white,
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: MediumTextSize),
-                              )
-                            ])
-                          : CircularProgressIndicator(
-                              strokeWidth: 4,
-                              valueColor: AlwaysStoppedAnimation(NavyBlue),
+    return TemplateBaseViewModel<HomeScreenViewModel>(
+        onModelReady: (model) => model.loadTransporterInfo(),
+        builder: (context, model, child) => BusyOverlayScreen(
+              show: model.state == ViewState.Busy,
+              child: Scaffold(
+                backgroundColor: Beige,
+                appBar: appBarInner('Home Screen'),
+                body: Center(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: <Widget>[
+                        Stack(
+                          alignment: Alignment.center,
+                          children: <Widget>[
+                            Image.asset("assets/home_cover.jpg"),
+                            Positioned(
+                              bottom: 20.0,
+                              left: 10.0,
+                              child: model.transporter != null
+                                  ? Column(children: [
+                                      if (model.transporter.isAdmin)
+                                        Text(
+                                          'Administrator',
+                                          style: TextStyle(
+                                              color: Colors.white,
+                                              fontWeight: FontWeight.bold,
+                                              fontSize: MediumTextSize),
+                                        ),
+                                      Text(
+                                        '${model.transporter.firstName} ${model.transporter.lastName}',
+                                        style: TextStyle(
+                                            color: Colors.white,
+                                            fontWeight: FontWeight.bold,
+                                            fontSize: MediumTextSize),
+                                      )
+                                    ])
+                                  : CircularProgressIndicator(
+                                      strokeWidth: 4,
+                                      valueColor:
+                                          AlwaysStoppedAnimation(NavyBlue),
+                                    ),
                             ),
-                    ),
-                    Positioned(
-                        bottom: 0.0,
-                        right: 0.0,
-                        child: IconButton(
-                          icon: Icon(Icons.edit),
-                          color: Colors.white,
-                          onPressed: model.navigateToAccountScreen,
-                        )),
-                    Positioned(
-                      child: model.transporter != null
-                          ? CircleAvatar(
-                              radius: 52,
-                              backgroundColor: NavyBlue,
-                              child: CircleAvatar(
-                                  radius: 50,
-                                  backgroundColor: Colors.grey[300],
-                                  backgroundImage: model.transporter
-                                          .displayImageUrl.isNotEmpty
-                                      ? NetworkImage(
-                                          model.transporter.displayImageUrl)
-                                      : NetworkImage(defaultImage)),
+                            Positioned(
+                                bottom: 0.0,
+                                right: 0.0,
+                                child: IconButton(
+                                  icon: Icon(Icons.edit),
+                                  color: Colors.white,
+                                  onPressed: model.navigateToAccountScreen,
+                                )),
+                            Positioned(
+                              child: model.transporter != null
+                                  ? CircleAvatar(
+                                      radius: 52,
+                                      backgroundColor: NavyBlue,
+                                      child: CircleAvatar(
+                                          radius: 50,
+                                          backgroundColor: Colors.grey[300],
+                                          backgroundImage: model.transporter
+                                                  .displayImageUrl.isNotEmpty
+                                              ? NetworkImage(model
+                                                  .transporter.displayImageUrl)
+                                              : NetworkImage(defaultImage)),
+                                    )
+                                  : CircularProgressIndicator(
+                                      strokeWidth: 4,
+                                      valueColor:
+                                          AlwaysStoppedAnimation(NavyBlue),
+                                    ),
                             )
-                          : CircularProgressIndicator(
-                              strokeWidth: 4,
-                              valueColor: AlwaysStoppedAnimation(NavyBlue),
+                          ],
+                        ),
+                        ListView(
+                          shrinkWrap: true,
+                          padding: const EdgeInsets.all(10.0),
+                          children: <Widget>[
+                            RaisedButton.icon(
+                              onPressed: model.startNewAtr,
+                              padding: EdgeInsets.all(30.0),
+                              icon: Icon(
+                                Icons.add_circle,
+                                color: NavyBlue,
+                                size: 40.0,
+                              ),
+                              color: Colors.white,
+                              label: Text(
+                                'New Form',
+                                style: TextStyle(
+                                    fontStyle: FontStyle.italic,
+                                    fontSize: 20.0,
+                                    fontWeight: FontWeight.bold,
+                                    color: NavyBlue),
+                                textAlign: TextAlign.left,
+                              ),
                             ),
-                    )
-                  ],
+                            Padding(
+                              padding: EdgeInsets.only(
+                                top: 10.0,
+                              ),
+                            ),
+                            RaisedButton.icon(
+                              onPressed: model.navigateToActiveScreen,
+                              padding: EdgeInsets.all(30.0),
+                              icon: Icon(
+                                Icons.wifi_protected_setup,
+                                color: NavyBlue,
+                                size: 40.0,
+                              ),
+                              color: Colors.white,
+                              label: Text(
+                                'Active Form',
+                                style: TextStyle(
+                                    fontStyle: FontStyle.italic,
+                                    fontSize: 20.0,
+                                    fontWeight: FontWeight.bold,
+                                    color: NavyBlue),
+                              ),
+                            ),
+                            Padding(
+                              padding: EdgeInsets.only(
+                                top: 10.0,
+                              ),
+                            ),
+                            RaisedButton.icon(
+                              onPressed: model.navigateToHistoryScreen,
+                              padding: EdgeInsets.all(30.0),
+                              icon: Icon(
+                                Icons.history_sharp,
+                                color: NavyBlue,
+                                size: 40.0,
+                              ),
+                              color: Colors.white,
+                              label: Text(
+                                'Travel History',
+                                style: TextStyle(
+                                    fontStyle: FontStyle.italic,
+                                    fontSize: 20.0,
+                                    fontWeight: FontWeight.bold,
+                                    color: NavyBlue),
+                              ),
+                            ),
+                            Padding(
+                              padding: EdgeInsets.only(
+                                top: 10.0,
+                              ),
+                            ),
+                            RaisedButton.icon(
+                              onPressed: model.signOut,
+                              padding: EdgeInsets.all(30.0),
+                              icon: Icon(
+                                Icons.logout,
+                                color: NavyBlue,
+                                size: 40.0,
+                              ),
+                              color: Colors.white,
+                              label: Text(
+                                'Sign Out',
+                                style: TextStyle(
+                                    fontStyle: FontStyle.italic,
+                                    fontSize: 20.0,
+                                    fontWeight: FontWeight.bold,
+                                    color: NavyBlue),
+                              ),
+                            ),
+                          ],
+                        )
+                      ],
+                    ),
+                  ),
                 ),
-                ListView(
-                  shrinkWrap: true,
-                  padding: const EdgeInsets.all(10.0),
-                  children: <Widget>[
-                    RaisedButton.icon(
-                      onPressed: model.startNewAtr,
-                      padding: EdgeInsets.all(30.0),
-                      icon: Icon(
-                        Icons.add_circle,
-                        color: NavyBlue,
-                        size: 40.0,
-                      ),
-                      color: Colors.white,
-                      label: Text(
-                        'New Form',
-                        style: TextStyle(
-                            fontStyle: FontStyle.italic,
-                            fontSize: 20.0,
-                            fontWeight: FontWeight.bold,
-                            color: NavyBlue),
-                        textAlign: TextAlign.left,
-                      ),
-                    ),
-                    Padding(
-                      padding: EdgeInsets.only(
-                        top: 10.0,
-                      ),
-                    ),
-                    RaisedButton.icon(
-                      onPressed: model.navigateToActiveScreen,
-                      padding: EdgeInsets.all(30.0),
-                      icon: Icon(
-                        Icons.wifi_protected_setup,
-                        color: NavyBlue,
-                        size: 40.0,
-                      ),
-                      color: Colors.white,
-                      label: Text(
-                        'Active Form',
-                        style: TextStyle(
-                            fontStyle: FontStyle.italic,
-                            fontSize: 20.0,
-                            fontWeight: FontWeight.bold,
-                            color: NavyBlue),
-                      ),
-                    ),
-                    Padding(
-                      padding: EdgeInsets.only(
-                        top: 10.0,
-                      ),
-                    ),
-                    RaisedButton.icon(
-                      onPressed: model.navigateToHistoryScreen,
-                      padding: EdgeInsets.all(30.0),
-                      icon: Icon(
-                        Icons.history_sharp,
-                        color: NavyBlue,
-                        size: 40.0,
-                      ),
-                      color: Colors.white,
-                      label: Text(
-                        'Travel History',
-                        style: TextStyle(
-                            fontStyle: FontStyle.italic,
-                            fontSize: 20.0,
-                            fontWeight: FontWeight.bold,
-                            color: NavyBlue),
-                      ),
-                    ),
-                    Padding(
-                      padding: EdgeInsets.only(
-                        top: 10.0,
-                      ),
-                    ),
-                    RaisedButton.icon(
-                      onPressed: model.signOut,
-                      padding: EdgeInsets.all(30.0),
-                      icon: Icon(
-                        Icons.logout,
-                        color: NavyBlue,
-                        size: 40.0,
-                      ),
-                      color: Colors.white,
-                      label: Text(
-                        'Sign Out',
-                        style: TextStyle(
-                            fontStyle: FontStyle.italic,
-                            fontSize: 20.0,
-                            fontWeight: FontWeight.bold,
-                            color: NavyBlue),
-                      ),
-                    ),
-                  ],
-                )
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
+              ),
+            ));
   }
 }

--- a/app/lib/ui/widgets/utility/pdf_screen.dart
+++ b/app/lib/ui/widgets/utility/pdf_screen.dart
@@ -43,28 +43,36 @@ class _PDFScreenState extends State<PDFScreen> {
         builder: (BuildContext context, AsyncSnapshot<List> snapshot) {
           switch (snapshot.connectionState) {
             case ConnectionState.waiting:
-              return Container(
-                  color: Beige,
-                  child: Stack(
-                    alignment: FractionalOffset.center,
-                    children: <Widget>[
-                      new Container(
-                        child: new CircularProgressIndicator(
-                          backgroundColor: NavyBlue,
-                        ),
-                      ),
-                    ],
+              return Scaffold(
+                  appBar: AppBar(
+                    iconTheme: IconThemeData(color: NavyBlue),
+                    backgroundColor: Beige,
+                    title: Text(
+                      'PDF View',
+                      style: TextStyle(color: NavyBlue),
+                    ),
+                  ),
+                  body: Center(
+                    child: CircularProgressIndicator(
+                      backgroundColor: NavyBlue,
+                    ),
                   ));
             default:
               if (snapshot.hasError) {
-                return Container(
-                    padding: EdgeInsets.all(20),
-                    alignment: Alignment.center,
-                    color: Colors.white,
-                    child: Text(
+                return Scaffold(
+                    appBar: AppBar(
+                      iconTheme: IconThemeData(color: NavyBlue),
+                      backgroundColor: Beige,
+                      title: Text(
+                        'PDF View',
+                        style: TextStyle(color: NavyBlue),
+                      ),
+                    ),
+                    body: Center(
+                        child: Text(
                       'Could not build and save PDF: ${snapshot.error}',
                       style: TitleTextStyle,
-                    ));
+                    )));
               } else {
                 return TemplateBaseViewModel<PdfScreenViewModel>(
                     builder: (context, model, child) => Scaffold(

--- a/app/test/core/services/auth_service_test.dart
+++ b/app/test/core/services/auth_service_test.dart
@@ -33,7 +33,11 @@ void main() {
   void setUpFirebaseAuthMock() {
     when(mockFirebaseAuth.createUserWithEmailAndPassword(
             email: userEmailAddress, password: password))
-        .thenAnswer((_) async => mockUserCredential);
+        .thenAnswer((_) async {
+      // The .timeout call requires this cast to be explicit
+      UserCredential inner() => mockUserCredential;
+      return inner();
+    });
     when(mockUserCredential.user).thenReturn(mockUser);
     when(mockUser.uid).thenReturn(testUserId);
   }

--- a/app/test/core/services/database/database_service_test.dart
+++ b/app/test/core/services/database/database_service_test.dart
@@ -64,6 +64,8 @@ void main() {
           .thenReturn(mockCollectionReference);
       when(mockCollectionReference.doc(transporterModel.userId))
           .thenReturn(mockDocumentReference);
+      when(mockDocumentReference.set(transporterModel.toJSON()))
+          .thenAnswer((_) => Future.value({}));
       await dbService.addTransporter(transporterModel);
       verify(mockDocumentReference.set(transporterModel.toJSON())).called(1);
     });


### PR DESCRIPTION
Closes #234 .

This PR adds:
1. Time limit of 10s to internet futures as per https://stackoverflow.com/a/61518327
2. Continue using futures against the suggestion of https://stackoverflow.com/a/53551036
3. Adds `BusyOverlay` to home screen

**We should continue to use futures because they provide us with useful error messages, like permission denied. Without them, debugging would be a lot harder and more confusing for the Transporter** 

***

Changes aren't much, but when the device is offline we will see:

Blank images when offline
![Blank images when offline ](https://user-images.githubusercontent.com/32527219/112742439-c7a91c00-8f4b-11eb-82da-0e6812052daf.png)

PDF View never completes because it can't get images from the internet, but the user can just back out from the screen rather than wait now
![PDF View sits forever, but that's fine because we can leave](https://user-images.githubusercontent.com/32527219/112742440-c841b280-8f4b-11eb-8520-72a87329af49.png)

We see this message when a timeout occurs:
![Good future error](https://user-images.githubusercontent.com/32527219/112743079-5cfadf00-8f51-11eb-83ed-31f9c702b54f.png)
