### PR TITLE
Add simple filtering to Active and History screens.

### DIFF
--- a/app/lib/core/view_models/active_screen_view_model.dart
+++ b/app/lib/core/view_models/active_screen_view_model.dart
@@ -38,6 +38,11 @@ class ActiveScreenViewModel extends BaseViewModel {
   List<AnimalTransportRecord> get animalTransportRecords =>
       List.unmodifiable(_animalTransportRecords);
 
+  List<AnimalTransportRecord> _filteredAnimalTransportRecords = [];
+
+  List<AnimalTransportRecord> get filteredAnimalTransportRecords =>
+      List.unmodifiable(_filteredAnimalTransportRecords);
+
   ActiveScreenViewModel() {
     final thisUser = _authenticationService.currentUser;
     if (thisUser.isPresent()) {
@@ -74,15 +79,25 @@ class ActiveScreenViewModel extends BaseViewModel {
 
   void addAll(List<AnimalTransportRecord> atrs) {
     _animalTransportRecords.addAll(atrs);
+    _filteredAnimalTransportRecords = _animalTransportRecords;
     notifyListeners();
   }
 
   void removeAll() {
     _animalTransportRecords.clear();
+    _filteredAnimalTransportRecords.clear();
     notifyListeners();
   }
 
-// May have come from Home screen or Active screen
+  void filterBySearchTerm(String searchTerm) {
+    _filteredAnimalTransportRecords = _animalTransportRecords
+        .where((AnimalTransportRecord atr) =>
+            atr.toString().toLowerCase().contains(searchTerm.toLowerCase()))
+        .toList();
+    notifyListeners();
+  }
+
+  // May have come from Home screen or Active screen
   void navigateBack() => _navigationService.pop();
 
   void navigateToHomeScreen() =>

--- a/app/lib/core/view_models/history_screen_view_model.dart
+++ b/app/lib/core/view_models/history_screen_view_model.dart
@@ -33,6 +33,11 @@ class HistoryScreenViewModel extends BaseViewModel {
   List<AnimalTransportRecord> get animalTransportRecords =>
       List.unmodifiable(_animalTransportRecords);
 
+  List<AnimalTransportRecord> _filteredAnimalTransportRecords = [];
+
+  List<AnimalTransportRecord> get filteredAnimalTransportRecords =>
+      List.unmodifiable(_filteredAnimalTransportRecords);
+
   HistoryScreenViewModel() {
     final thisUser = _authenticationService.currentUser;
     if (thisUser.isPresent()) {
@@ -85,11 +90,21 @@ class HistoryScreenViewModel extends BaseViewModel {
 
   void addAll(List<AnimalTransportRecord> atrs) {
     _animalTransportRecords.addAll(atrs);
+    _filteredAnimalTransportRecords = _animalTransportRecords;
     notifyListeners();
   }
 
   void removeAll() {
     _animalTransportRecords.clear();
+    _filteredAnimalTransportRecords.clear();
+    notifyListeners();
+  }
+
+  void filterBySearchTerm(String searchTerm) {
+    _filteredAnimalTransportRecords = _animalTransportRecords
+        .where((AnimalTransportRecord atr) =>
+            atr.toString().toLowerCase().contains(searchTerm.toLowerCase()))
+        .toList();
     notifyListeners();
   }
 

--- a/app/lib/ui/views/active/active_screen.dart
+++ b/app/lib/ui/views/active/active_screen.dart
@@ -22,6 +22,7 @@ class _ActiveScreenState extends State<ActiveScreen> {
           key: ObjectKey(Uuid().v4()),
           atr: atr,
           onTap: () => model.navigateToEditingScreen(atr));
+
   @override
   Widget build(BuildContext context) {
     return TemplateBaseViewModel<ActiveScreenViewModel>(
@@ -68,33 +69,47 @@ class _ActiveScreenState extends State<ActiveScreen> {
                   label: "New Form",
                 )
               ]),
-          body: model.animalTransportRecords.isEmpty
-              ? Center(
-                  child: Container(
-                    margin: EdgeInsets.all(50.0),
-                    child: Card(
-                      child: ListTile(
-                          title: Text(
-                            "No active Animal Transport Records",
-                            textAlign: TextAlign.center,
-                          ),
-                          subtitle: Text(
-                            "You can add some using the \"New\" button",
-                            textAlign: TextAlign.center,
-                          )),
-                    ),
-                  ),
-                )
-              : GridView.builder(
-                  itemCount: model.animalTransportRecords.length,
-                  itemBuilder: (context, index) =>
-                      createPreview(model, model.animalTransportRecords[index]),
-                  gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-                      maxCrossAxisExtent: 200,
-                      childAspectRatio: 9 / 8,
-                      crossAxisSpacing: 20,
-                      mainAxisSpacing: 20),
-                ),
+          body: Column(
+            children: [
+              Card(
+                  child: Padding(
+                      padding: EdgeInsets.all(5.0),
+                      child: TextFormField(
+                        decoration: InputDecoration(
+                            border: OutlineInputBorder(), labelText: "Search"),
+                        onFieldSubmitted: (String searchTerm) =>
+                            model.filterBySearchTerm(searchTerm),
+                      ))),
+              model.animalTransportRecords.isEmpty
+                  ? Center(
+                      child: Container(
+                        margin: EdgeInsets.all(50.0),
+                        child: Card(
+                          child: ListTile(
+                              title: Text(
+                                "No active Animal Transport Records",
+                                textAlign: TextAlign.center,
+                              ),
+                              subtitle: Text(
+                                "You can add some using the \"New\" button",
+                                textAlign: TextAlign.center,
+                              )),
+                        ),
+                      ),
+                    )
+                  : Expanded(
+                      child: GridView.builder(
+                      itemCount: model.filteredAnimalTransportRecords.length,
+                      itemBuilder: (context, index) => createPreview(
+                          model, model.filteredAnimalTransportRecords[index]),
+                      gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+                          maxCrossAxisExtent: 200,
+                          childAspectRatio: 9 / 8,
+                          crossAxisSpacing: 20,
+                          mainAxisSpacing: 20),
+                    )),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/ui/views/history/history_screen.dart
+++ b/app/lib/ui/views/history/history_screen.dart
@@ -24,61 +24,75 @@ class _HistoryScreenState extends State<HistoryScreen> {
   @override
   Widget build(BuildContext context) {
     return TemplateBaseViewModel<HistoryScreenViewModel>(
-      builder: (context, model, _) => Scaffold(
-          appBar: appBarInner('Travel History'),
-          backgroundColor: Beige,
-          bottomNavigationBar: BottomNavigationBar(
-              unselectedLabelStyle: TextStyle(fontSize: SmallTextSize),
-              selectedItemColor: NavyBlue,
-              unselectedItemColor: NavyBlue,
-              backgroundColor: SlateGrey,
-              onTap: (int item) async {
-                switch (item) {
-                  case 0:
-                    return model.navigateToHomeScreen();
-                  case 1:
-                    return model.navigateToActiveScreen();
-                }
-              },
-              items: [
-                BottomNavigationBarItem(
-                  icon: Icon(
-                    Icons.arrow_back,
-                    color: NavyBlue,
-                  ),
-                  label: "Back",
-                ),
-                BottomNavigationBarItem(
-                  icon: Icon(
-                    Icons.directions_car,
-                    color: NavyBlue,
-                  ),
-                  label: "Active",
-                ),
-              ]),
-          body: model.animalTransportRecords.isEmpty
-              ? Center(
-                  child: Container(
-                    margin: EdgeInsets.all(50.0),
-                    child: Card(
-                      child: ListTile(
-                        title: Text("No completed Animal Transport Records"),
-                        subtitle: Text(
-                            "Submitted completed records will appear here"),
+        builder: (context, model, _) => Scaffold(
+              appBar: appBarInner('Travel History'),
+              backgroundColor: Beige,
+              bottomNavigationBar: BottomNavigationBar(
+                  unselectedLabelStyle: TextStyle(fontSize: SmallTextSize),
+                  selectedItemColor: NavyBlue,
+                  unselectedItemColor: NavyBlue,
+                  backgroundColor: SlateGrey,
+                  onTap: (int item) async {
+                    switch (item) {
+                      case 0:
+                        return model.navigateToHomeScreen();
+                      case 1:
+                        return model.navigateToActiveScreen();
+                    }
+                  },
+                  items: [
+                    BottomNavigationBarItem(
+                      icon: Icon(
+                        Icons.arrow_back,
+                        color: NavyBlue,
                       ),
+                      label: "Back",
                     ),
-                  ),
-                )
-              : GridView.builder(
-                  itemCount: model.animalTransportRecords.length,
-                  itemBuilder: (_, index) =>
-                      createPreview(model, model.animalTransportRecords[index]),
-                  gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-                      maxCrossAxisExtent: 200,
-                      childAspectRatio: 9 / 8,
-                      crossAxisSpacing: 20,
-                      mainAxisSpacing: 20),
-                )),
-    );
+                    BottomNavigationBarItem(
+                      icon: Icon(
+                        Icons.directions_car,
+                        color: NavyBlue,
+                      ),
+                      label: "Active",
+                    ),
+                  ]),
+              body: Column(children: [
+                Card(
+                    child: Padding(
+                        padding: EdgeInsets.all(5.0),
+                        child: TextFormField(
+                          decoration: InputDecoration(
+                              border: OutlineInputBorder(),
+                              labelText: "Search"),
+                          onFieldSubmitted: (String searchTerm) =>
+                              model.filterBySearchTerm(searchTerm),
+                        ))),
+                model.animalTransportRecords.isEmpty
+                    ? Center(
+                        child: Container(
+                          margin: EdgeInsets.all(50.0),
+                          child: Card(
+                            child: ListTile(
+                              title:
+                                  Text("No completed Animal Transport Records"),
+                              subtitle: Text(
+                                  "Submitted completed records will appear here"),
+                            ),
+                          ),
+                        ),
+                      )
+                    : Expanded(
+                        child: GridView.builder(
+                        itemCount: model.filteredAnimalTransportRecords.length,
+                        itemBuilder: (context, index) => createPreview(
+                            model, model.filteredAnimalTransportRecords[index]),
+                        gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+                            maxCrossAxisExtent: 200,
+                            childAspectRatio: 9 / 8,
+                            crossAxisSpacing: 20,
+                            mainAxisSpacing: 20),
+                      )),
+              ]),
+            ));
   }
 }


### PR DESCRIPTION
Closes #209  .

This first attempt will not refilter the records when a new record comes in, (the filtered records are tied to the incoming records) so the user will have to search again when the list updates (simple as pressing enter again).

This seems acceptable to me as admins will not miss a record when filtering.

***

Changes look like:


https://user-images.githubusercontent.com/32527219/113233803-3e505d00-925d-11eb-9d3e-d65666e84d67.mp4


https://user-images.githubusercontent.com/32527219/113233848-5e801c00-925d-11eb-95c3-e10e6dfa0a4a.mp4



https://user-images.githubusercontent.com/32527219/113234063-cafb1b00-925d-11eb-93a8-09943c683a01.mp4



https://user-images.githubusercontent.com/32527219/113234022-b74fb480-925d-11eb-91c5-a51df3fea1b9.mp4

