### PR TITLE
Changed PDF Viewer plugins again

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -48,6 +48,9 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.debug
+            minifyEnabled true
+            useProguard true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/app/android/proguard-rules.pro
+++ b/app/android/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Flutter wrapper
+-keep class com.shockwave.**

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -212,8 +212,6 @@ PODS:
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/meta/type_traits
-  - advance_pdf_viewer (1.0.5):
-    - Flutter
   - BoringSSL-GRPC (0.0.7):
     - BoringSSL-GRPC/Implementation (= 0.0.7)
     - BoringSSL-GRPC/Interface (= 0.0.7)
@@ -278,9 +276,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_email_sender (0.0.1):
     - Flutter
-  - FMDB (2.7.5):
-    - FMDB/standard (= 2.7.5)
-  - FMDB/standard (2.7.5)
+  - flutter_pdfview (1.0.2):
+    - Flutter
   - GoogleDataTransport (8.1.0):
     - nanopb (~> 2.30906.0)
   - GoogleUtilities/AppDelegateSwizzler (7.2.2):
@@ -340,26 +337,22 @@ PODS:
   - PromisesObjC (1.2.12)
   - shared_preferences (0.0.1):
     - Flutter
-  - sqflite (0.0.2):
-    - Flutter
-    - FMDB (>= 2.7.5)
   - url_launcher (0.0.1):
     - Flutter
 
 DEPENDENCIES:
-  - advance_pdf_viewer (from `.symlinks/plugins/advance_pdf_viewer/ios`)
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
   - Flutter (from `Flutter`)
   - flutter_email_sender (from `.symlinks/plugins/flutter_email_sender/ios`)
+  - flutter_pdfview (from `.symlinks/plugins/flutter_pdfview/ios`)
   - image_picker (from `.symlinks/plugins/image_picker/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
   - shared_preferences (from `.symlinks/plugins/shared_preferences/ios`)
-  - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
 
 SPEC REPOS:
@@ -372,7 +365,6 @@ SPEC REPOS:
     - FirebaseCoreDiagnostics
     - FirebaseFirestore
     - FirebaseStorage
-    - FMDB
     - GoogleDataTransport
     - GoogleUtilities
     - "gRPC-C++"
@@ -383,8 +375,6 @@ SPEC REPOS:
     - PromisesObjC
 
 EXTERNAL SOURCES:
-  advance_pdf_viewer:
-    :path: ".symlinks/plugins/advance_pdf_viewer/ios"
   cloud_firestore:
     :path: ".symlinks/plugins/cloud_firestore/ios"
   firebase_auth:
@@ -397,6 +387,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_email_sender:
     :path: ".symlinks/plugins/flutter_email_sender/ios"
+  flutter_pdfview:
+    :path: ".symlinks/plugins/flutter_pdfview/ios"
   image_picker:
     :path: ".symlinks/plugins/image_picker/ios"
   integration_test:
@@ -407,14 +399,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler/ios"
   shared_preferences:
     :path: ".symlinks/plugins/shared_preferences/ios"
-  sqflite:
-    :path: ".symlinks/plugins/sqflite/ios"
   url_launcher:
     :path: ".symlinks/plugins/url_launcher/ios"
 
 SPEC CHECKSUMS:
   abseil: 6c8eb7892aefa08d929b39f9bb108e5367e3228f
-  advance_pdf_viewer: 5c832f382b4ca84fe735f893b7e91aa830c27d7b
   BoringSSL-GRPC: 8edf627ee524575e2f8d19d56f068b448eea3879
   cloud_firestore: 357b92d4778d7715d76a393db5f89e7dcc9b7401
   Firebase: 26223c695fe322633274198cb19dca8cb7e54416
@@ -428,7 +417,7 @@ SPEC CHECKSUMS:
   FirebaseStorage: 5002b1895bfe74a5ce92ad54f966e6162d0da2e5
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   flutter_email_sender: 02d7443217d8c41483223627972bfdc09f74276b
-  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
+  flutter_pdfview: 25f53dd6097661e6395b17de506e6060585946bd
   GoogleDataTransport: 116c84c4bdeb76be2a7a46de51244368f9794eab
   GoogleUtilities: 31c5b01f978a70c6cff2afc6272b3f1921614b43
   "gRPC-C++": 13d8ccef97d5c3c441b7e3c529ef28ebee86fad2
@@ -442,7 +431,6 @@ SPEC CHECKSUMS:
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   shared_preferences: af6bfa751691cdc24be3045c43ec037377ada40d
-  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 
 PODFILE CHECKSUM: fe0e1ee7f3d1f7d00b11b474b62dd62134535aea

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -52,10 +52,9 @@
     <string>Can I use the mic please?</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Example usage description</string>
-
-	<!-- Permission options for the `photos` group -->
+    <key>io.flutter.embedded_views_preview</key>
+    <true/>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>photos</string>
-
 </dict>
 </plist>

--- a/app/lib/ui/widgets/utility/pdf_screen.dart
+++ b/app/lib/ui/widgets/utility/pdf_screen.dart
@@ -94,6 +94,7 @@ class _PDFScreenState extends State<PDFScreen> {
                             ],
                           ),
                           body: PDFView(
+                              // The file path is relative on iOS but is absolute on Android
                               filePath: Platform.isIOS
                                   ? snapshot.data.path
                                   : snapshot.data.uri.toString()),

--- a/app/lib/ui/widgets/utility/pdf_screen.dart
+++ b/app/lib/ui/widgets/utility/pdf_screen.dart
@@ -93,7 +93,10 @@ class _PDFScreenState extends State<PDFScreen> {
                                   ))
                             ],
                           ),
-                          body: PDFView(filePath: snapshot.data.uri.toString()),
+                          body: PDFView(
+                              filePath: Platform.isIOS
+                                  ? snapshot.data.path
+                                  : snapshot.data.uri.toString()),
                         ));
               }
           }

--- a/app/lib/ui/widgets/utility/pdf_screen.dart
+++ b/app/lib/ui/widgets/utility/pdf_screen.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 
-import 'package:advance_pdf_viewer/advance_pdf_viewer.dart';
 import 'package:app/core/models/animal_transport_record.dart';
 import 'package:app/core/view_models/pdf_screen_view_model.dart';
 import 'package:app/ui/common/style.dart';
@@ -10,6 +9,7 @@ import 'package:app/ui/widgets/utility/template_base_view_model.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_pdfview/flutter_pdfview.dart';
 import 'package:network_image_to_byte/network_image_to_byte.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:pdf/pdf.dart';
@@ -26,21 +26,19 @@ class PDFScreen extends StatefulWidget {
 }
 
 class _PDFScreenState extends State<PDFScreen> {
-  Future<PDFDocument> document;
   Future<File> file;
 
   @override
   void initState() {
     file = _getBuiltAndSavedPdf(widget.atr);
-    document = file.then((File file) => PDFDocument.fromFile(file));
     super.initState();
   }
 
   @override
   build(BuildContext context) {
-    return FutureBuilder<List>(
-        future: Future.wait([file, document]),
-        builder: (BuildContext context, AsyncSnapshot<List> snapshot) {
+    return FutureBuilder<File>(
+        future: file,
+        builder: (BuildContext context, AsyncSnapshot<File> snapshot) {
           switch (snapshot.connectionState) {
             case ConnectionState.waiting:
               return Scaffold(
@@ -86,7 +84,7 @@ class _PDFScreenState extends State<PDFScreen> {
                             actions: [
                               OutlinedButton.icon(
                                   onPressed: () {
-                                    model.navigateToEmailForm(snapshot.data[0]);
+                                    model.navigateToEmailForm(snapshot.data);
                                   },
                                   icon: Icon(Icons.mail, color: NavyBlue),
                                   label: Text(
@@ -95,12 +93,7 @@ class _PDFScreenState extends State<PDFScreen> {
                                   ))
                             ],
                           ),
-                          body: PDFViewer(
-                            pickerButtonColor: NavyBlue,
-                            document: snapshot.data[1],
-                            zoomSteps: 1,
-                            scrollDirection: Axis.vertical,
-                          ),
+                          body: PDFView(filePath: snapshot.data.uri.toString()),
                         ));
               }
           }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -8,13 +8,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "14.0.0"
-  advance_pdf_viewer:
-    dependency: "direct main"
-    description:
-      name: advance_pdf_viewer
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.2"
   analyzer:
     dependency: transitive
     description:
@@ -272,13 +265,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_cache_manager:
-    dependency: transitive
-    description:
-      name: flutter_cache_manager
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.2"
   flutter_driver:
     dependency: "direct dev"
     description: flutter
@@ -312,6 +298,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.6"
+  flutter_pdfview:
+    dependency: "direct main"
+    description:
+      name: flutter_pdfview
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -390,13 +383,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
-  infinite_listview:
-    dependency: transitive
-    description:
-      name: infinite_listview
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1+1"
   integration_test:
     dependency: "direct dev"
     description:
@@ -488,13 +474,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
-  numberpicker:
-    dependency: transitive
-    description:
-      name: numberpicker
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   package_config:
     dependency: transitive
     description:
@@ -635,13 +614,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
-  rxdart:
-    dependency: transitive
-    description:
-      name: rxdart
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.25.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -703,20 +675,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0-nullsafety.2"
-  sqflite:
-    dependency: transitive
-    description:
-      name: sqflite
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.2+4"
-  sqflite_common:
-    dependency: transitive
-    description:
-      name: sqflite_common
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.3+3"
   stack_trace:
     dependency: transitive
     description:
@@ -745,13 +703,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
-  synchronized:
-    dependency: transitive
-    description:
-      name: synchronized
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.0+2"
   term_glyph:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -23,7 +23,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  advance_pdf_viewer: ^1.2.2
   cloud_firestore: ^0.16.0+1
   cupertino_icons: ^1.0.0
   crypto: ^2.1.5
@@ -34,6 +33,7 @@ dependencies:
   flutter_email_sender: ^4.0.0
   flutter_launcher_icons: ^0.8.0
   flutter_multi_formatter: ^1.3.6
+  flutter_pdfview: ^1.0.4
   get_it: ^5.0.6
   image_picker: ^0.6.7+21
   mockito: ^4.1.4
@@ -46,7 +46,7 @@ dependencies:
   google_fonts: ^1.1.2
   network_image_to_byte: ^0.0.1
   flutter_linkify: ^4.0.2
-  url_launcher: '>=5.4.0 <6.0.0'
+  url_launcher: ^5.7.10
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
Many of these PDF plugins are in different states of maturity

Added `proguard-rules` as the release build will require it for the `flutter_pdfview` plugin [as per their documentation](https://pub.dev/packages/flutter_pdfview#for-production-usage).

***

Changes simple remove the fun buttons from the last plugin in exchange for working on iOS:

![pdf](https://user-images.githubusercontent.com/32527219/113971108-5d1e9880-97f5-11eb-80f7-e843b3b22d31.png)
