### PR TITLE
Update validation message on editing screen to provide more guidance

### DIFF
--- a/app/lib/ui/views/active/form_field/loading_vehicle_info_form_field.dart
+++ b/app/lib/ui/views/active/form_field/loading_vehicle_info_form_field.dart
@@ -1,4 +1,6 @@
 import 'package:app/core/models/loading_vehicle_info.dart';
+import 'package:app/core/services/service_locator.dart';
+import 'package:app/core/services/validation_service.dart';
 import 'package:app/ui/common/style.dart';
 import 'package:app/ui/views/active/dynamic_form_field/dynamic_animal_group_form_field.dart';
 import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
@@ -7,6 +9,7 @@ import 'package:app/ui/widgets/utility/date_time_picker.dart';
 import 'package:flutter/material.dart';
 
 class LoadingVehicleInfoFormField extends StatefulWidget {
+  final ValidationService _validator = locator<ValidationService>();
   final Function(LoadingVehicleInfo info) onSaved;
   final LoadingVehicleInfo initialInfo;
   final String title = "Loading Vehicle Information";
@@ -58,6 +61,13 @@ class _LoadingVehicleInfoFormFieldState
   // Only one call to saved them is needed as this form's fields are saved together
   void _saveNestedForms() => _animalsLoadedFormField.save();
 
+  // The nested save is blocked by validate so we save then validate,
+  // validation must be true before submission so this is fine
+  bool _saveAndValidateNestedForms() {
+    _saveNestedForms();
+    return _animalsLoadedFormField.validate();
+  }
+
   void _saveAll() => widget.onSaved(LoadingVehicleInfo(
       dateAndTimeLoaded: _dateAndTimeLoaded,
       loadingArea: _loadingArea,
@@ -98,6 +108,9 @@ class _LoadingVehicleInfoFormFieldState
         IntFormField(
             initial: _loadingArea,
             title: "Floor or container area available to animals (m2 or ft2)",
+            validator: (int it) => _saveAndValidateNestedForms()
+                ? widget._validator.intFieldValidator(it)
+                : "*Something is missing. Try the save button!",
             onSaved: (int changed) {
               _loadingArea = changed;
               _saveNestedForms();

--- a/app/lib/ui/views/active/form_field/transporter_info_form_field.dart
+++ b/app/lib/ui/views/active/form_field/transporter_info_form_field.dart
@@ -1,5 +1,7 @@
 import 'package:app/core/models/address.dart';
 import 'package:app/core/models/transporter_info.dart';
+import 'package:app/core/services/service_locator.dart';
+import 'package:app/core/services/validation_service.dart';
 import 'package:app/core/utilities/optional.dart';
 import 'package:app/ui/common/style.dart';
 import 'package:app/ui/views/active/dynamic_form_field/dynamic_form_field.dart';
@@ -10,6 +12,7 @@ import 'package:app/ui/widgets/utility/date_time_picker.dart';
 import 'package:flutter/material.dart';
 
 class TransporterInfoFormField extends StatefulWidget {
+  final ValidationService _validator = locator<ValidationService>();
   final Function(TransporterInfo info) onSaved;
   final TransporterInfo initialInfo;
   final String title = "Transporter's Information";
@@ -93,6 +96,13 @@ class _TransporterInfoFormFieldState extends State<TransporterInfoFormField> {
   // Only one call to saved them is needed as this form's fields are saved together
   void _saveNestedForms() => _driverNamesFormField.save();
 
+  // The nested save is blocked by validate so we save then validate,
+  // validation must be true before submission so this is fine
+  bool _saveAndValidateNestedForms() {
+    _saveNestedForms();
+    return _driverNamesFormField.validate();
+  }
+
   void _saveAll() => widget.onSaved(TransporterInfo(
       companyName: _companyName,
       companyAddress: _companyAddress,
@@ -129,6 +139,9 @@ class _TransporterInfoFormFieldState extends State<TransporterInfoFormField> {
         StringFormField(
             initial: _companyName,
             title: "Name of transporting company",
+            validator: (String it) => _saveAndValidateNestedForms()
+                ? widget._validator.stringFieldValidator(it)
+                : "*Something is missing. Try the save button!",
             onSaved: (String changed) {
               _companyName = changed;
               _saveNestedForms();

--- a/app/lib/ui/widgets/utility/date_time_picker.dart
+++ b/app/lib/ui/widgets/utility/date_time_picker.dart
@@ -1,9 +1,14 @@
+import 'package:app/core/services/service_locator.dart';
+import 'package:app/core/services/validation_service.dart';
 import 'package:date_time_picker/date_time_picker.dart';
 import 'package:flutter/material.dart';
 
 DateTimePicker dateTimePicker(
-        {@required DateTime initialDate, @required Function(String) onSaved}) =>
+        {@required DateTime initialDate,
+        @required Function(String) onSaved,
+        FormFieldValidator<String> validator}) =>
     DateTimePicker(
+      validator: validator ?? locator<ValidationService>().stringFieldValidator,
       decoration: InputDecoration(border: OutlineInputBorder()),
       type: DateTimePickerType.dateTimeSeparate,
       initialValue: initialDate.toString(),


### PR DESCRIPTION
This PR updates validation to block submission when nested form fields are invalid. In watching Clark's instruction videos, I didn't like the error messages and such he was given (stupid nested forms) so this work fixes that some more.

@MummenRider please try this update on your emulator and verify it works for you as you expect.